### PR TITLE
FIGI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Check-digit calculation is also available.
 Currently supported standards:
 [ISIN](https://en.wikipedia.org/wiki/International_Securities_Identification_Number),
 [CUSIP](https://en.wikipedia.org/wiki/CUSIP),
-[SEDOL](https://en.wikipedia.org/wiki/SEDOL)
+[SEDOL](https://en.wikipedia.org/wiki/SEDOL),
+[FIGI](https://en.wikipedia.org/wiki/Financial_Instrument_Global_Identifier).
 
 Work in progress:
 [IBAN](https://en.wikipedia.org/wiki/International_Bank_Account_Number).
@@ -155,6 +156,27 @@ cusip.valid?                # => true
 cusip.valid_format?         # => true
 cusip.restore!              # => 'B0Z52W5'
 cusip.calculate_check_digit # => 5
+```
+
+### SecId::FIGI full example
+
+```ruby
+# class level
+SecId::FIGI.valid?('BBG000DMBXR2')        # => true
+SecId::FIGI.valid_format?('BBG000DMBXR2') # => true
+SecId::FIGI.restore!('BBG000DMBXR')       # => 'BBG000DMBXR2'
+SecId::FIGI.check_digit('BBG000DMBXR')    # => 2
+
+# instance level
+figi = SecId::FIGI.new('BBG000DMBXR2')
+figi.full_number           # => 'BBG000DMBXR2'
+figi.prefix                # => 'BB'
+figi.random_part           # => '000DMBXR'
+figi.check_digit           # => 2
+figi.valid?                # => true
+figi.valid_format?         # => true
+figi.restore!              # => 'BBG000DMBXR2'
+figi.calculate_check_digit # => 2
 ```
 
 ## Development

--- a/lib/sec_id.rb
+++ b/lib/sec_id.rb
@@ -6,6 +6,7 @@ require 'sec_id/base'
 require 'sec_id/isin'
 require 'sec_id/cusip'
 require 'sec_id/sedol'
+require 'sec_id/figi'
 
 module SecId
   Error = Class.new(StandardError)

--- a/lib/sec_id/figi.rb
+++ b/lib/sec_id/figi.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module SecId
+  class FIGI < Base
+    ID_REGEX = /\A
+      (?<identifier>
+        (?<prefix>[B-DF-HJ-NP-TV-Z0-9]{2})
+        G
+        (?<random_part>[B-DF-HJ-NP-TV-Z0-9]{8}))
+      (?<check_digit>\d)?
+    \z/x
+
+    attr_reader :prefix, :random_part
+
+    def initialize(figi)
+      figi_parts = parse figi
+      @identifier = figi_parts[:identifier]
+      @prefix = figi_parts[:prefix]
+      @random_part = figi_parts[:random_part]
+      @check_digit = figi_parts[:check_digit]&.to_i
+    end
+
+    RESTRICTED_PREFIXES = Set.new %w[BS BM GG GB GH KY VG]
+
+    def valid_format?
+      !identifier.nil? and !RESTRICTED_PREFIXES.include?(prefix)
+    end
+
+    def calculate_check_digit
+      return mod10(modified_luhn_sum) if valid_format?
+
+      raise InvalidFormatError, "FIGI '#{full_number}' is invalid and check-digit cannot be calculated!"
+    end
+
+    private
+
+    def modified_luhn_sum
+      identifier[0, 11].reverse.chars.map.with_index do |char, index|
+        value = char_to_digit(char)
+        value *= 2 if index.odd?
+        value.to_s.chars.map(&:to_i)
+      end.flatten.sum
+    end
+  end
+end

--- a/spec/sec_id/figi_spec.rb
+++ b/spec/sec_id/figi_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+RSpec.describe SecId::FIGI do
+  let(:figi) { described_class.new(figi_number) }
+
+  context 'when FIGI is valid' do
+    let(:figi_number) { 'BBG000H4FSM0' }
+
+    it 'parses FIGI correctly' do
+      expect(figi.identifier).to eq('BBG000H4FSM')
+      expect(figi.prefix).to eq('BB')
+      expect(figi.random_part).to eq('000H4FSM')
+      expect(figi.check_digit).to eq(0)
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(figi.valid?).to be(true)
+      end
+    end
+
+    describe '#restore!' do
+      it 'restores check-digit and returns full FIGI number' do
+        expect(figi.restore!).to eq(figi_number)
+        expect(figi.full_number).to eq(figi_number)
+      end
+    end
+  end
+
+  context 'when FIGI has a restricted prefix' do
+    let(:figi_number) { 'BSGF4YQD8PV0' }
+
+    it 'parses FIGI correctly' do
+      expect(figi.identifier).to eq('BSGF4YQD8PV')
+      expect(figi.prefix).to eq('BS')
+      expect(figi.random_part).to eq('F4YQD8PV')
+      expect(figi.check_digit).to eq(0)
+    end
+
+    describe '#valid?' do
+      it 'returns false' do
+        expect(figi.valid?).to be(false)
+      end
+    end
+
+    describe '#restore!' do
+      it 'raises an error' do
+        expect { figi.restore! }.to raise_error(SecId::InvalidFormatError)
+      end
+    end
+  end
+
+  context 'when FIGI is missing prefix' do
+    let(:figi_number) { 'G000BLNQ16' }
+
+    it 'parses FIGI correctly' do
+      expect(figi.identifier).to be_nil
+      expect(figi.prefix).to be_nil
+      expect(figi.random_part).to be_nil
+      expect(figi.check_digit).to be_nil
+    end
+
+    describe '#valid?' do
+      it 'returns false' do
+        expect(figi.valid?).to be(false)
+      end
+    end
+
+    describe '#restore!' do
+      it 'raises an error' do
+        expect { figi.restore! }.to raise_error(SecId::InvalidFormatError)
+      end
+    end
+  end
+
+  context 'when FIGI number is missing check-digit' do
+    let(:figi_number) { 'BBG000BLNQ1' }
+
+    it 'parses FIGI correctly' do
+      expect(figi.identifier).to eq(figi_number)
+      expect(figi.prefix).to eq('BB')
+      expect(figi.random_part).to eq('000BLNQ1')
+      expect(figi.check_digit).to be_nil
+    end
+
+    describe '#valid?' do
+      it 'returns false' do
+        expect(figi.valid?).to be(false)
+      end
+    end
+
+    describe '#restore!' do
+      it 'restores check-digit and returns full FIGI number' do
+        expect(figi.restore!).to eq('BBG000BLNQ16')
+        expect(figi.full_number).to eq('BBG000BLNQ16')
+      end
+    end
+  end
+
+  describe '.valid?' do
+    context 'when FIGI is incorrect' do
+      it 'returns false' do
+        expect(described_class.valid?('US03783315')).to be(false)
+        expect(described_class.valid?('US037833104')).to be(false)
+        expect(described_class.valid?('US0378331004')).to be(false) # invalid check-digit
+        expect(described_class.valid?('US03783315123')).to be(false)
+      end
+    end
+
+    context 'when FIGI is valid' do
+      it 'returns true' do
+        %w[KKG000000M81 BBG008B8STT7 BBG00QRVW6J5 BBG001S6RDX9 BBG000CJYWS6].each do |figi_number|
+          expect(described_class.valid?(figi_number)).to be(true)
+        end
+      end
+    end
+  end
+
+  describe '.restore!' do
+    context 'when FIGI is incorrect' do
+      it 'raises an error' do
+        expect { described_class.restore!('BBG000HY4H') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.restore!('BBG000HY4HWX') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.restore!('BBG000HY4HW90') }.to raise_error(SecId::InvalidFormatError)
+      end
+    end
+
+    context 'when FIGI is valid' do
+      it 'restores check-digit and returns full FIGI number' do
+        expect(described_class.restore!('BBG000HY4HW')).to eq('BBG000HY4HW9')
+        expect(described_class.restore!('BBG000HY4HW9')).to eq('BBG000HY4HW9')
+        expect(described_class.restore!('BBG000BCK0D')).to eq('BBG000BCK0D3')
+        expect(described_class.restore!('BBG000BCK0D3')).to eq('BBG000BCK0D3')
+        expect(described_class.restore!('BBG000BKRK3')).to eq('BBG000BKRK35')
+      end
+    end
+  end
+
+  describe '.valid_format?' do
+    context 'when FIGI has a disallowed prefix' do
+      it 'returns false' do
+        expect(described_class.valid_format?('GGGKFNH88CW')).to be(false)
+        expect(described_class.valid_format?('GBGFFK4C9TP')).to be(false)
+        expect(described_class.valid_format?('GHGH4FR4J04')).to be(false)
+        expect(described_class.valid_format?('KYGLM70ZJQD')).to be(false)
+        expect(described_class.valid_format?('VGG19LLVFTH')).to be(false)
+      end
+    end
+
+    context 'when FIGI is incorrect' do
+      it 'returns false' do
+        expect(described_class.valid_format?('BBG000HY4H')).to be(false)
+        expect(described_class.valid_format?('BB 000HY4HW')).to be(false)
+        expect(described_class.valid_format?('BBG000HY4HWX')).to be(false)
+        expect(described_class.valid_format?('BBG000HY4HW90')).to be(false)
+      end
+    end
+
+    context 'when FIGI is valid or missing check-digit' do
+      it 'returns true' do
+        expect(described_class.valid_format?('BBG000HY4HW')).to be(true)
+        expect(described_class.valid_format?('BBG000HY4HW9')).to be(true)
+        expect(described_class.valid_format?('BBG000BCK0D')).to be(true)
+        expect(described_class.valid_format?('BBG000BCK0D3')).to be(true)
+        expect(described_class.valid_format?('BBG000BKRK3')).to be(true)
+      end
+    end
+  end
+
+  describe '.check_digit' do
+    context 'when FIGI is incorrect' do
+      it 'raises an error' do
+        expect { described_class.check_digit('BBG000HY4H') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.check_digit('BBG000HY4HWX') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.check_digit('BBG000HY4HW90') }.to raise_error(SecId::InvalidFormatError)
+      end
+    end
+
+    context 'when FIGI is valid' do
+      it 'calculates and returns the check-digit' do
+        expect(described_class.check_digit('BBG000HY4HW')).to eq(9)
+        expect(described_class.check_digit('BBG000HY4HW9')).to eq(9)
+        expect(described_class.check_digit('BBG000BCK0D')).to eq(3)
+        expect(described_class.check_digit('BBG000BCK0D3')).to eq(3)
+        expect(described_class.check_digit('BBG000BKRK3')).to eq(5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
For reference:

- [OMG: Financial Instrument Global Identifier](https://www.omg.org/figi/)
- [OpenFIGI: About FIGI](https://www.openfigi.com/about/figi)
- [Kaiko: Crypto FIGI](https://www.kaiko.com/support/crypto-figi)
- [ANSI X9.145-2021](https://x9.org/wp-content/uploads/2021/08/ANSI-X9.145-2021-Financial-Instrument-Global-Identifier-FIGI.pdf) (PDF)