### PR TITLE
CINS check method for CUSIPs

### DIFF
--- a/lib/sec_id/cusip.rb
+++ b/lib/sec_id/cusip.rb
@@ -35,6 +35,11 @@ module SecId
       isin
     end
 
+    # CUSIP International Numbering System
+    def cins?
+      !cusip6[0].match?(/[0-9]/)
+    end
+
     private
 
     # https://en.wikipedia.org/wiki/Luhn_algorithm

--- a/spec/sec_id/cusip_spec.rb
+++ b/spec/sec_id/cusip_spec.rb
@@ -89,6 +89,24 @@ RSpec.describe SecId::CUSIP do
     end
   end
 
+  describe '#cins?' do
+    context 'when a CINS' do
+      let(:cusip_number) { 'G0052B105' }
+
+      it 'returns true' do
+        expect(cusip.cins?).to be(true)
+      end
+    end
+
+    context 'when not a CINS' do
+      let(:cusip_number) { '084664BL4' }
+
+      it 'returns false' do
+        expect(cusip.cins?).to be(false)
+      end
+    end
+  end
+
   describe '.restore!' do
     context 'when CUSIP is incorrect' do
       it 'raises an error' do


### PR DESCRIPTION
CINS is an acronym for the [CUSIP International Numbering System](https://www.cusip.com/identifiers.html#/CINS) and refers to CUSIP identifiers that start with a letter.

The [OpenFIGI API](https://www.openfigi.com/api#v3-idType-values) considers CUSIP and CINS to be different types, so it would be nice to have this convenience method.