### PR TITLE
Capitalize as SecID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SecId
+# SecID
 [![Gem Version](https://badge.fury.io/rb/sec_id.svg)](https://badge.fury.io/rb/sec_id)
 ![Build Status](https://github.com/svyatov/sec_id/actions/workflows/main.yml/badge.svg?branch=main)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a4759963a5ddc4d55b24/maintainability)](https://codeclimate.com/github/svyatov/sec_id/maintainability)
@@ -45,11 +45,11 @@ Base API has 4 main methods which can be used both on class level and on instanc
 
   ```ruby
   # class level
-  SecId::ISIN.valid?('US5949181045') # => true
-  SecId::ISIN.valid?('US594918104')  # => false
+  SecID::ISIN.valid?('US5949181045') # => true
+  SecID::ISIN.valid?('US594918104')  # => false
 
   # instance level
-  isin = SecId::ISIN.new('US5949181045')
+  isin = SecID::ISIN.new('US5949181045')
   isin.valid? # => true
   ```
 
@@ -58,11 +58,11 @@ Base API has 4 main methods which can be used both on class level and on instanc
 
   ```ruby
   # class level
-  SecId::ISIN.valid_format?('US5949181045') # => true
-  SecId::ISIN.valid_format?('US594918104') # => true
+  SecID::ISIN.valid_format?('US5949181045') # => true
+  SecID::ISIN.valid_format?('US594918104') # => true
 
   # instance level
-  isin = SecId::ISIN.new('US594918104')
+  isin = SecID::ISIN.new('US594918104')
   isin.valid_format? # => true
   ```
 
@@ -71,10 +71,10 @@ Base API has 4 main methods which can be used both on class level and on instanc
 
   ```ruby
   # class level
-  SecId::ISIN.restore!('US594918104') # => 'US5949181045'
+  SecID::ISIN.restore!('US594918104') # => 'US5949181045'
 
   # instance level
-  isin = SecId::ISIN.new('US5949181045')
+  isin = SecID::ISIN.new('US5949181045')
   isin.restore! # => 'US5949181045'
   ```
 
@@ -86,10 +86,10 @@ Base API has 4 main methods which can be used both on class level and on instanc
 
   ```ruby
   # class level
-  SecId::ISIN.check_digit('US594918104') # => 5
+  SecID::ISIN.check_digit('US594918104') # => 5
 
   # instance level
-  isin = SecId::ISIN.new('US594918104')
+  isin = SecID::ISIN.new('US594918104')
   isin.calculate_check_digit # => 5
   isin.check_digit # => nil
   ```
@@ -98,17 +98,17 @@ Base API has 4 main methods which can be used both on class level and on instanc
   at instance level represents original check-digit of the number passed to `new`,
   which in this example is missing and thus it's `nil`.
 
-### SecId::ISIN full example
+### SecID::ISIN full example
 
 ```ruby
 # class level
-SecId::ISIN.valid?('US5949181045')       # => true
-SecId::ISIN.valid_format?('US594918104') # => true
-SecId::ISIN.restore!('US594918104')      # => 'US5949181045'
-SecId::ISIN.check_digit('US594918104')   # => 5
+SecID::ISIN.valid?('US5949181045')       # => true
+SecID::ISIN.valid_format?('US594918104') # => true
+SecID::ISIN.restore!('US594918104')      # => 'US5949181045'
+SecID::ISIN.check_digit('US594918104')   # => 5
 
 # instance level
-isin = SecId::ISIN.new('US5949181045')
+isin = SecID::ISIN.new('US5949181045')
 isin.full_number           # => 'US5949181045'
 isin.country_code          # => 'US'
 isin.nsin                  # => '594918104'
@@ -117,20 +117,20 @@ isin.valid?                # => true
 isin.valid_format?         # => true
 isin.restore!              # => 'US5949181045'
 isin.calculate_check_digit # => 5
-isin.to_cusip              # => #<SecId::CUSIP>
+isin.to_cusip              # => #<SecID::CUSIP>
 ```
 
-### SecId::CUSIP full example
+### SecID::CUSIP full example
 
 ```ruby
 # class level
-SecId::CUSIP.valid?('594918104')       # => true
-SecId::CUSIP.valid_format?('59491810') # => true
-SecId::CUSIP.restore!('59491810')      # => '594918104'
-SecId::CUSIP.check_digit('59491810')   # => 5
+SecID::CUSIP.valid?('594918104')       # => true
+SecID::CUSIP.valid_format?('59491810') # => true
+SecID::CUSIP.restore!('59491810')      # => '594918104'
+SecID::CUSIP.check_digit('59491810')   # => 5
 
 # instance level
-cusip = SecId::CUSIP.new('594918104')
+cusip = SecID::CUSIP.new('594918104')
 cusip.full_number           # => '594918104'
 cusip.cusip6                # => '594918'
 cusip.issue                 # => '10'
@@ -139,21 +139,21 @@ cusip.valid?                # => true
 cusip.valid_format?         # => true
 cusip.restore!              # => '594918104'
 cusip.calculate_check_digit # => 4
-cusip.to_isin('US')         # => #<SecId::ISIN>
+cusip.to_isin('US')         # => #<SecID::ISIN>
 cusip.cins?                 # => true
 ```
 
-### SecId::SEDOL full example
+### SecID::SEDOL full example
 
 ```ruby
 # class level
-SecId::SEDOL.valid?('B0Z52W5')       # => true
-SecId::SEDOL.valid_format?('B0Z52W') # => true
-SecId::SEDOL.restore!('B0Z52W')      # => 'B0Z52W5'
-SecId::SEDOL.check_digit('B0Z52W')   # => 5
+SecID::SEDOL.valid?('B0Z52W5')       # => true
+SecID::SEDOL.valid_format?('B0Z52W') # => true
+SecID::SEDOL.restore!('B0Z52W')      # => 'B0Z52W5'
+SecID::SEDOL.check_digit('B0Z52W')   # => 5
 
 # instance level
-cusip = SecId::SEDOL.new('B0Z52W5')
+cusip = SecID::SEDOL.new('B0Z52W5')
 cusip.full_number           # => 'B0Z52W5'
 cusip.check_digit           # => 5
 cusip.valid?                # => true
@@ -162,17 +162,17 @@ cusip.restore!              # => 'B0Z52W5'
 cusip.calculate_check_digit # => 5
 ```
 
-### SecId::FIGI full example
+### SecID::FIGI full example
 
 ```ruby
 # class level
-SecId::FIGI.valid?('BBG000DMBXR2')        # => true
-SecId::FIGI.valid_format?('BBG000DMBXR2') # => true
-SecId::FIGI.restore!('BBG000DMBXR')       # => 'BBG000DMBXR2'
-SecId::FIGI.check_digit('BBG000DMBXR')    # => 2
+SecID::FIGI.valid?('BBG000DMBXR2')        # => true
+SecID::FIGI.valid_format?('BBG000DMBXR2') # => true
+SecID::FIGI.restore!('BBG000DMBXR')       # => 'BBG000DMBXR2'
+SecID::FIGI.check_digit('BBG000DMBXR')    # => 2
 
 # instance level
-figi = SecId::FIGI.new('BBG000DMBXR2')
+figi = SecID::FIGI.new('BBG000DMBXR2')
 figi.full_number           # => 'BBG000DMBXR2'
 figi.prefix                # => 'BB'
 figi.random_part           # => '000DMBXR'
@@ -183,17 +183,17 @@ figi.restore!              # => 'BBG000DMBXR2'
 figi.calculate_check_digit # => 2
 ```
 
-### SecId::CIK full example
+### SecID::CIK full example
 
 ```ruby
 # class level
-SecId::CIK.valid?('0001094517')        # => true
-SecId::CIK.valid_format?('0001094517') # => true
-SecId::CIK.restore!('1094517')         # => '0001094517'
-SecId::CIK.check_digit('0001094517')   # raises NotImplementedError
+SecID::CIK.valid?('0001094517')        # => true
+SecID::CIK.valid_format?('0001094517') # => true
+SecID::CIK.restore!('1094517')         # => '0001094517'
+SecID::CIK.check_digit('0001094517')   # raises NotImplementedError
 
 # instance level
-cik = SecId::CIK.new('0001094517')
+cik = SecID::CIK.new('0001094517')
 cik.full_number           # => '0001094517'
 cik.padding               # => '000'
 cik.identifier            # => '1094517'

--- a/lib/sec_id.rb
+++ b/lib/sec_id.rb
@@ -9,7 +9,7 @@ require 'sec_id/sedol'
 require 'sec_id/figi'
 require 'sec_id/cik'
 
-module SecId
+module SecID
   Error = Class.new(StandardError)
   InvalidFormatError = Class.new(Error)
 end

--- a/lib/sec_id/base.rb
+++ b/lib/sec_id/base.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SecId
+module SecID
   CHAR_TO_DIGITS = {
     '0' => 0,      '1' => 1,      '2' => 2,      '3' => 3,      '4' => 4,
     '5' => 5,      '6' => 6,      '7' => 7,      '8' => 8,      '9' => 9,
@@ -84,11 +84,11 @@ module SecId
     end
 
     def char_to_digits(char)
-      SecId::CHAR_TO_DIGITS.fetch(char)
+      SecID::CHAR_TO_DIGITS.fetch(char)
     end
 
     def char_to_digit(char)
-      SecId::CHAR_TO_DIGIT.fetch(char)
+      SecID::CHAR_TO_DIGIT.fetch(char)
     end
 
     def mod10(sum)

--- a/lib/sec_id/cik.rb
+++ b/lib/sec_id/cik.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SecId
+module SecID
   # https://en.wikipedia.org/wiki/Central_Index_Key
   class CIK < Base
     ID_REGEX = /\A

--- a/lib/sec_id/cusip.rb
+++ b/lib/sec_id/cusip.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SecId
+module SecID
   # https://en.wikipedia.org/wiki/CUSIP
   class CUSIP < Base
     ID_REGEX = /\A

--- a/lib/sec_id/figi.rb
+++ b/lib/sec_id/figi.rb
@@ -2,7 +2,7 @@
 
 require 'set'
 
-module SecId
+module SecID
   class FIGI < Base
     ID_REGEX = /\A
       (?<identifier>

--- a/lib/sec_id/isin.rb
+++ b/lib/sec_id/isin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SecId
+module SecID
   # https://en.wikipedia.org/wiki/International_Securities_Identification_Number
   class ISIN < Base
     ID_REGEX = /\A

--- a/lib/sec_id/sedol.rb
+++ b/lib/sec_id/sedol.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SecId
+module SecID
   # https://en.wikipedia.org/wiki/SEDOL
   class SEDOL < Base
     ID_REGEX = /\A

--- a/lib/sec_id/version.rb
+++ b/lib/sec_id/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module SecId
+module SecID
   VERSION = '4.1.0'
 end

--- a/sec_id.gemspec
+++ b/sec_id.gemspec
@@ -6,7 +6,7 @@ require 'sec_id/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'sec_id'
-  spec.version       = SecId::VERSION
+  spec.version       = SecID::VERSION
   spec.authors       = ['Leonid Svyatov']
   spec.email         = ['leonid@svyatov.ru']
 

--- a/spec/sec_id/cik_spec.rb
+++ b/spec/sec_id/cik_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe SecId::CIK do
+RSpec.describe SecID::CIK do
   let(:cik) { described_class.new(cik_number) }
 
   context 'when CIK is valid' do
@@ -82,9 +82,9 @@ RSpec.describe SecId::CIK do
   describe '.restore!' do
     context 'when CIK is malformed' do
       it 'raises an error' do
-        expect { described_class.restore!('X9') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.restore!('0000000000') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.restore!('09876543210') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.restore!('X9') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.restore!('0000000000') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.restore!('09876543210') }.to raise_error(SecID::InvalidFormatError)
       end
     end
 

--- a/spec/sec_id/cusip_spec.rb
+++ b/spec/sec_id/cusip_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe SecId::CUSIP do
+RSpec.describe SecID::CUSIP do
   let(:cusip) { described_class.new(cusip_number) }
 
   context 'when CUSIP is valid' do
@@ -76,7 +76,7 @@ RSpec.describe SecId::CUSIP do
       let(:cusip_number) { '02153X108' }
 
       it 'returns an ISIN' do
-        expect(cusip.to_isin('VI')).to be_a(SecId::ISIN)
+        expect(cusip.to_isin('VI')).to be_a(SecID::ISIN)
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe SecId::CUSIP do
       let(:cusip_number) { '00B296YR7' }
 
       it 'raises an error' do
-        expect { cusip.to_isin('IE') }.to raise_error(SecId::InvalidFormatError)
+        expect { cusip.to_isin('IE') }.to raise_error(SecID::InvalidFormatError)
       end
     end
   end
@@ -110,8 +110,8 @@ RSpec.describe SecId::CUSIP do
   describe '.restore!' do
     context 'when CUSIP is incorrect' do
       it 'raises an error' do
-        expect { described_class.restore!('68389X1') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.restore!('68389X1055') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.restore!('68389X1') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.restore!('68389X1055') }.to raise_error(SecID::InvalidFormatError)
       end
     end
 
@@ -148,8 +148,8 @@ RSpec.describe SecId::CUSIP do
   describe '.check_digit' do
     context 'when CUSIP is incorrect' do
       it 'raises an error' do
-        expect { described_class.check_digit('9861913') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.check_digit('9861913025') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.check_digit('9861913') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.check_digit('9861913025') }.to raise_error(SecID::InvalidFormatError)
       end
     end
 

--- a/spec/sec_id/figi_spec.rb
+++ b/spec/sec_id/figi_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe SecId::FIGI do
+RSpec.describe SecID::FIGI do
   let(:figi) { described_class.new(figi_number) }
 
   context 'when FIGI is valid' do
@@ -45,7 +45,7 @@ RSpec.describe SecId::FIGI do
 
     describe '#restore!' do
       it 'raises an error' do
-        expect { figi.restore! }.to raise_error(SecId::InvalidFormatError)
+        expect { figi.restore! }.to raise_error(SecID::InvalidFormatError)
       end
     end
   end
@@ -68,7 +68,7 @@ RSpec.describe SecId::FIGI do
 
     describe '#restore!' do
       it 'raises an error' do
-        expect { figi.restore! }.to raise_error(SecId::InvalidFormatError)
+        expect { figi.restore! }.to raise_error(SecID::InvalidFormatError)
       end
     end
   end
@@ -119,9 +119,9 @@ RSpec.describe SecId::FIGI do
   describe '.restore!' do
     context 'when FIGI is incorrect' do
       it 'raises an error' do
-        expect { described_class.restore!('BBG000HY4H') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.restore!('BBG000HY4HWX') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.restore!('BBG000HY4HW90') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.restore!('BBG000HY4H') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.restore!('BBG000HY4HWX') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.restore!('BBG000HY4HW90') }.to raise_error(SecID::InvalidFormatError)
       end
     end
 
@@ -170,9 +170,9 @@ RSpec.describe SecId::FIGI do
   describe '.check_digit' do
     context 'when FIGI is incorrect' do
       it 'raises an error' do
-        expect { described_class.check_digit('BBG000HY4H') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.check_digit('BBG000HY4HWX') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.check_digit('BBG000HY4HW90') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.check_digit('BBG000HY4H') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.check_digit('BBG000HY4HWX') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.check_digit('BBG000HY4HW90') }.to raise_error(SecID::InvalidFormatError)
       end
     end
 

--- a/spec/sec_id/isin_spec.rb
+++ b/spec/sec_id/isin_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe SecId::ISIN do
+RSpec.describe SecID::ISIN do
   let(:isin) { described_class.new(isin_number) }
 
   context 'when ISIN is valid' do
@@ -45,7 +45,7 @@ RSpec.describe SecId::ISIN do
 
     describe '#restore!' do
       it 'raises an error' do
-        expect { isin.restore! }.to raise_error(SecId::InvalidFormatError)
+        expect { isin.restore! }.to raise_error(SecID::InvalidFormatError)
       end
     end
   end
@@ -80,7 +80,7 @@ RSpec.describe SecId::ISIN do
 
       it 'returns a CUSIP' do
         expect(isin.cgs?).to be(true)
-        expect(isin.to_cusip).to be_a(SecId::CUSIP)
+        expect(isin.to_cusip).to be_a(SecID::CUSIP)
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe SecId::ISIN do
 
       it 'raises an error' do
         expect(isin.cgs?).to be(false)
-        expect { isin.to_cusip }.to raise_error(SecId::InvalidFormatError)
+        expect { isin.to_cusip }.to raise_error(SecID::InvalidFormatError)
       end
     end
   end
@@ -122,8 +122,8 @@ RSpec.describe SecId::ISIN do
   describe '.restore!' do
     context 'when ISIN is incorrect' do
       it 'raises an error' do
-        expect { described_class.restore!('US03783315') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.restore!('US03783315123') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.restore!('US03783315') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.restore!('US03783315123') }.to raise_error(SecID::InvalidFormatError)
       end
     end
 
@@ -160,8 +160,8 @@ RSpec.describe SecId::ISIN do
   describe '.check_digit' do
     context 'when ISIN is incorrect' do
       it 'raises an error' do
-        expect { described_class.check_digit('US03783315') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.check_digit('US03783315123') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.check_digit('US03783315') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.check_digit('US03783315123') }.to raise_error(SecID::InvalidFormatError)
       end
     end
 

--- a/spec/sec_id/sedol_spec.rb
+++ b/spec/sec_id/sedol_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe SecId::SEDOL do
+RSpec.describe SecID::SEDOL do
   let(:sedol) { described_class.new(sedol_number) }
 
   context 'when SEDOL is valid' do
@@ -70,8 +70,8 @@ RSpec.describe SecId::SEDOL do
   describe '.restore!' do
     context 'when SEDOL is incorrect' do
       it 'raises an error' do
-        expect { described_class.restore!('I09CB4') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.restore!('B09CBL40') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.restore!('I09CB4') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.restore!('B09CBL40') }.to raise_error(SecID::InvalidFormatError)
       end
     end
 
@@ -108,8 +108,8 @@ RSpec.describe SecId::SEDOL do
   describe '.check_digit' do
     context 'when SEDOL is incorrect' do
       it 'raises an error' do
-        expect { described_class.check_digit('55U290') }.to raise_error(SecId::InvalidFormatError)
-        expect { described_class.check_digit('55290275') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.check_digit('55U290') }.to raise_error(SecID::InvalidFormatError)
+        expect { described_class.check_digit('55290275') }.to raise_error(SecID::InvalidFormatError)
       end
     end
 

--- a/spec/sec_id_spec.rb
+++ b/spec/sec_id_spec.rb
@@ -2,8 +2,8 @@
 
 require 'spec_helper'
 
-RSpec.describe SecId do
+RSpec.describe SecID do
   it 'has a version number' do
-    expect(SecId::VERSION).not_to be_nil
+    expect(SecID::VERSION).not_to be_nil
   end
 end


### PR DESCRIPTION
It would be nice to change the parent module name to SecID, similar to OpenID, OpenSSL, ERB, IO, et cetera.

For situations where the current name is needed, the module can be aliased readily:
```ruby
SecId = ::SecID
```