### PR TITLE
Use rubocop plugin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rspec
 
 AllCops:

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,8 @@ gem 'rake', '>= 13'
 gem 'rspec', '~> 3.9'
 gem 'rspec_junit_formatter'
 
-gem 'rubocop', '~> 1.64'
-gem 'rubocop-rspec', '~> 3.0'
+gem 'rubocop', '~> 1.72'
+gem 'rubocop-rspec', '~> 3.5'
 
 gem 'simplecov', '~> 0.22', require: false
 gem 'simplecov_json_formatter', require: false


### PR DESCRIPTION
When running `rubocop` I got the following warning:

```
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in sec_id/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```
