### PR TITLE
Make CIK standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,19 +189,17 @@ figi.calculate_check_digit # => 2
 # class level
 SecId::CIK.valid?('0001094517')        # => true
 SecId::CIK.valid_format?('0001094517') # => true
-SecId::CIK.restore!('1094517')         # => '0001094517'
-SecId::CIK.check_digit('0001094517')   # raises NotImplementedError
+SecId::CIK.normalize!('1094517')       # => '0001094517'
 
 # instance level
 cik = SecId::CIK.new('0001094517')
-cik.full_number           # => '0001094517'
-cik.padding               # => '000'
-cik.identifier            # => '1094517'
-cik.valid?                # => true
-cik.valid_format?         # => true
-cik.restore!              # => '0001094517'
-cik.calculate_check_digit # raises NotImplementedError
-cik.check_digit           # => nil
+cik.full_number   # => '0001094517'
+cik.padding       # => '000'
+cik.identifier    # => '1094517'
+cik.valid?        # => true
+cik.valid_format? # => true
+cik.normalize!    # => '0001094517'
+cik.to_s          # => '0001094517'
 ```
 
 ## Development

--- a/lib/sec_id/cik.rb
+++ b/lib/sec_id/cik.rb
@@ -2,15 +2,29 @@
 
 module SecId
   # https://en.wikipedia.org/wiki/Central_Index_Key
-  class CIK < Base
+  class CIK
     ID_REGEX = /\A
       (?=\d{1,10}\z)(?<padding>0*)(?<identifier>[1-9]\d{0,9})
     \z/x
 
-    attr_reader :padding
+    attr_reader :full_number, :identifier, :padding
+
+    class << self
+      def valid?(id)
+        new(id).valid?
+      end
+
+      def valid_format?(id)
+        new(id).valid_format?
+      end
+
+      def normalize!(id)
+        new(id).normalize!
+      end
+    end
 
     def initialize(cik)
-      cik_parts = parse cik
+      cik_parts = parse(cik)
       @padding = cik_parts[:padding]
       @identifier = cik_parts[:identifier]
     end
@@ -23,11 +37,23 @@ module SecId
       !identifier.nil?
     end
 
-    def restore!
-      raise InvalidFormatError, "CIK '#{full_number}' is invalid and cannot be restored!" unless valid_format?
+    def normalize!
+      raise InvalidFormatError, "CIK '#{full_number}' is invalid and cannot be normalized!" unless valid_format?
 
       @padding = '0' * (10 - @identifier.length)
       @full_number = @identifier.rjust(10, '0')
+    end
+
+    def to_s
+      full_number
+    end
+    alias to_str to_s
+
+    private
+
+    def parse(cik_number)
+      @full_number = cik_number.to_s.strip
+      @full_number.match(ID_REGEX) || {}
     end
   end
 end


### PR DESCRIPTION
I implemented a new class for this project (PR coming shortly) and found that inheriting from `Base` only makes sense for identifiers that have check digits (like `ISIN`).

So I updated `CIK` and made it standalone.