### PR TITLE
Add LEI (Legal Entity Identifier) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- LEI support (Legal Entity Identifier, ISO 17442)
+
 ### Updated
 
 - Improved README: better formatting, navigation, and clear API distinction between check-digit and normalization identifiers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Architecture
 
-This is a Ruby gem for validating securities identification numbers (ISIN, CUSIP, SEDOL, FIGI, CIK, OCC).
+This is a Ruby gem for validating securities identification numbers (ISIN, CUSIP, SEDOL, FIGI, LEI, CIK, OCC).
 
 ### Class Hierarchy
 
@@ -24,7 +24,7 @@ All identifier classes inherit from `SecId::Base` (`lib/sec_id/base.rb`), which 
 - Core API: `valid?`, `valid_format?`, `restore!`, `check_digit`/`calculate_check_digit`
 - Class-level convenience methods that delegate to instance methods
 - Character-to-digit conversion maps (`CHAR_TO_DIGITS`, `CHAR_TO_DIGIT`) for check-digit algorithms
-- Helper methods: `mod10`, `div10mod10`, `parse`
+- Helper methods: `mod10`, `div10mod10`, `mod97`, `parse`
 
 ### Identifier Classes
 
@@ -50,3 +50,11 @@ Each identifier type (`lib/sec_id/*.rb`) implements:
 - Max line length: 120 characters
 - RuboCop with rubocop-rspec extension
 - RSpec with `expect` syntax only (no monkey patching)
+
+## Pre-Commit Checklist
+
+Before committing changes, always verify these files are updated to accurately reflect the changes:
+
+- **README.md** - Update usage examples, Table of Contents, and supported standards list
+- **CHANGELOG.md** - Add entry under `[Unreleased]` section describing the change
+- **sec_id.gemspec** - Update `description` if adding/removing supported standards

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [CUSIP](#cusip) - Committee on Uniform Securities Identification Procedures
   - [SEDOL](#sedol) - Stock Exchange Daily Official List
   - [FIGI](#figi) - Financial Instrument Global Identifier
+  - [LEI](#lei) - Legal Entity Identifier
   - [CIK](#cik) - Central Index Key
   - [OCC](#occ) - Options Clearing Corporation Symbol
 - [Development](#development)
@@ -145,6 +146,30 @@ figi.valid?                # => true
 figi.valid_format?         # => true
 figi.restore!              # => 'BBG000DMBXR2'
 figi.calculate_check_digit # => 2
+```
+
+### LEI
+
+> [Legal Entity Identifier](https://en.wikipedia.org/wiki/Legal_Entity_Identifier) - a 20-character alphanumeric code that uniquely identifies legal entities participating in financial transactions.
+
+```ruby
+# class level
+SecId::LEI.valid?('5493006MHB84DD0ZWV18')       # => true
+SecId::LEI.valid_format?('5493006MHB84DD0ZWV')  # => true
+SecId::LEI.restore!('5493006MHB84DD0ZWV')       # => '5493006MHB84DD0ZWV18'
+SecId::LEI.check_digit('5493006MHB84DD0ZWV')    # => 18
+
+# instance level
+lei = SecId::LEI.new('5493006MHB84DD0ZWV18')
+lei.full_number           # => '5493006MHB84DD0ZWV18'
+lei.lou_id                # => '5493'
+lei.reserved              # => '00'
+lei.entity_id             # => '6MHB84DD0ZWV'
+lei.check_digit           # => 18
+lei.valid?                # => true
+lei.valid_format?         # => true
+lei.restore!              # => '5493006MHB84DD0ZWV18'
+lei.calculate_check_digit # => 18
 ```
 
 ### CIK

--- a/lib/sec_id.rb
+++ b/lib/sec_id.rb
@@ -7,6 +7,7 @@ require 'sec_id/isin'
 require 'sec_id/cusip'
 require 'sec_id/sedol'
 require 'sec_id/figi'
+require 'sec_id/lei'
 require 'sec_id/cik'
 require 'sec_id/occ'
 

--- a/lib/sec_id/base.rb
+++ b/lib/sec_id/base.rb
@@ -98,5 +98,9 @@ module SecId
     def div10mod10(number)
       (number / 10) + (number % 10)
     end
+
+    def mod97(numeric_string)
+      98 - (numeric_string.to_i % 97)
+    end
   end
 end

--- a/lib/sec_id/lei.rb
+++ b/lib/sec_id/lei.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module SecId
+  # https://en.wikipedia.org/wiki/Legal_Entity_Identifier
+  class LEI < Base
+    ID_REGEX = /\A
+      (?<identifier>
+        (?<lou_id>[0-9A-Z]{4})
+        (?<reserved>[0-9A-Z]{2})
+        (?<entity_id>[0-9A-Z]{12}))
+      (?<check_digit>\d{2})?
+    \z/x
+
+    attr_reader :lou_id, :reserved, :entity_id
+
+    def initialize(lei)
+      lei_parts = parse lei
+      @identifier = lei_parts[:identifier]
+      @lou_id = lei_parts[:lou_id]
+      @reserved = lei_parts[:reserved]
+      @entity_id = lei_parts[:entity_id]
+      @check_digit = lei_parts[:check_digit]&.to_i
+    end
+
+    def calculate_check_digit
+      unless valid_format?
+        raise InvalidFormatError, "LEI '#{full_number}' is invalid and check-digit cannot be calculated!"
+      end
+
+      mod97("#{numeric_identifier}00")
+    end
+
+    def to_s
+      return full_number unless check_digit
+
+      "#{identifier}#{check_digit.to_s.rjust(2, '0')}"
+    end
+
+    private
+
+    def numeric_identifier
+      identifier.each_char.map { |char| char_to_digit(char) }.join
+    end
+  end
+end

--- a/sec_id.gemspec
+++ b/sec_id.gemspec
@@ -11,7 +11,8 @@ Gem::Specification.new do |spec|
   spec.email         = ['leonid@svyatov.ru']
 
   spec.summary       = 'Validate securities identification numbers with ease!'
-  spec.description   = %(#{spec.summary} Currently supported standards: ISIN, CUSIP, SEDOL, FIGI, CIK, OCC.)
+  spec.description   = 'Validate, calculate check digits, and parse components of securities identifiers. ' \
+                       'Supports ISIN, CUSIP, SEDOL, FIGI, LEI, CIK, and OCC standards.'
   spec.homepage      = 'https://github.com/svyatov/sec_id'
   spec.license       = 'MIT'
 

--- a/spec/sec_id/lei_spec.rb
+++ b/spec/sec_id/lei_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+RSpec.describe SecId::LEI do
+  let(:lei) { described_class.new(lei_number) }
+
+  context 'when LEI is valid' do
+    let(:lei_number) { '5493006MHB84DD0ZWV18' }
+
+    it 'parses LEI correctly' do
+      expect(lei.identifier).to eq('5493006MHB84DD0ZWV')
+      expect(lei.lou_id).to eq('5493')
+      expect(lei.reserved).to eq('00')
+      expect(lei.entity_id).to eq('6MHB84DD0ZWV')
+      expect(lei.check_digit).to eq(18)
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(lei.valid?).to be(true)
+      end
+    end
+
+    describe '#restore!' do
+      it 'restores check-digit and returns full LEI' do
+        expect(lei.restore!).to eq(lei_number)
+        expect(lei.full_number).to eq(lei_number)
+      end
+    end
+
+    describe '#to_s' do
+      it 'returns full LEI' do
+        expect(lei.to_s).to eq(lei_number)
+      end
+    end
+  end
+
+  context 'when LEI has invalid check-digit' do
+    let(:lei_number) { '5493006MHB84DD0ZWV99' }
+
+    it 'parses LEI correctly' do
+      expect(lei.identifier).to eq('5493006MHB84DD0ZWV')
+      expect(lei.check_digit).to eq(99)
+    end
+
+    describe '#valid?' do
+      it 'returns false' do
+        expect(lei.valid?).to be(false)
+      end
+    end
+
+    describe '#restore!' do
+      it 'restores check-digit and returns corrected LEI' do
+        expect(lei.restore!).to eq('5493006MHB84DD0ZWV18')
+        expect(lei.full_number).to eq('5493006MHB84DD0ZWV18')
+      end
+    end
+  end
+
+  context 'when LEI is missing check-digit' do
+    let(:lei_number) { '5493006MHB84DD0ZWV' }
+
+    it 'parses LEI correctly' do
+      expect(lei.identifier).to eq(lei_number)
+      expect(lei.lou_id).to eq('5493')
+      expect(lei.reserved).to eq('00')
+      expect(lei.entity_id).to eq('6MHB84DD0ZWV')
+      expect(lei.check_digit).to be_nil
+    end
+
+    describe '#valid?' do
+      it 'returns false' do
+        expect(lei.valid?).to be(false)
+      end
+    end
+
+    describe '#restore!' do
+      it 'restores check-digit and returns full LEI' do
+        expect(lei.restore!).to eq('5493006MHB84DD0ZWV18')
+        expect(lei.full_number).to eq('5493006MHB84DD0ZWV18')
+      end
+    end
+  end
+
+  context 'when LEI has all-letter LOU identifier' do
+    let(:lei_number) { 'HWUPKR0MPOU8FGXBT394' }
+
+    it 'parses LEI correctly' do
+      expect(lei.identifier).to eq('HWUPKR0MPOU8FGXBT3')
+      expect(lei.lou_id).to eq('HWUP')
+      expect(lei.reserved).to eq('KR')
+      expect(lei.entity_id).to eq('0MPOU8FGXBT3')
+      expect(lei.check_digit).to eq(94)
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(lei.valid?).to be(true)
+      end
+    end
+
+    describe '#to_s' do
+      it 'returns full LEI' do
+        expect(lei.to_s).to eq(lei_number)
+      end
+    end
+  end
+
+  context 'when LEI format is invalid' do
+    let(:lei_number) { 'INVALID' }
+
+    it 'parses LEI as nil' do
+      expect(lei.identifier).to be_nil
+      expect(lei.lou_id).to be_nil
+      expect(lei.reserved).to be_nil
+      expect(lei.entity_id).to be_nil
+      expect(lei.check_digit).to be_nil
+    end
+
+    describe '#valid?' do
+      it 'returns false' do
+        expect(lei.valid?).to be(false)
+      end
+    end
+
+    describe '#restore!' do
+      it 'raises an error' do
+        expect { lei.restore! }.to raise_error(SecId::InvalidFormatError)
+      end
+    end
+  end
+
+  context 'when LEI contains lowercase letters' do
+    let(:lei_number) { '5493006mhb84dd0zwv18' }
+
+    it 'normalizes to uppercase and parses correctly' do
+      expect(lei.identifier).to eq('5493006MHB84DD0ZWV')
+      expect(lei.valid?).to be(true)
+    end
+  end
+
+  describe '.valid?' do
+    context 'when LEI is incorrect' do
+      it 'returns false' do
+        expect(described_class.valid?('INVALID')).to be(false)
+        expect(described_class.valid?('5493006MHB84DD0ZWV')).to be(false) # missing check-digit
+        expect(described_class.valid?('5493006MHB84DD0ZWV99')).to be(false) # wrong check-digit
+        expect(described_class.valid?('5493006MHB84DD0ZWV1')).to be(false) # too short
+        expect(described_class.valid?('5493006MHB84DD0ZWV123')).to be(false) # too long
+      end
+    end
+
+    context 'when LEI is valid' do
+      it 'returns true' do
+        # Real-world LEI examples
+        expect(described_class.valid?('5493006MHB84DD0ZWV18')).to be(true)
+        expect(described_class.valid?('529900T8BM49AURSDO55')).to be(true)
+        expect(described_class.valid?('HWUPKR0MPOU8FGXBT394')).to be(true)
+        expect(described_class.valid?('7ZW8QJWVPR4P1J1KQY45')).to be(true)
+        expect(described_class.valid?('549300TRUWO2CD2G5692')).to be(true)
+      end
+    end
+  end
+
+  describe '.valid_format?' do
+    context 'when LEI format is incorrect' do
+      it 'returns false' do
+        expect(described_class.valid_format?('INVALID')).to be(false)
+        expect(described_class.valid_format?('5493006MHB84DD0ZWV1')).to be(false) # too short
+        expect(described_class.valid_format?('5493006MHB84DD0ZWV123')).to be(false) # too long
+        expect(described_class.valid_format?('5493006MHB84DD0ZWV!!')).to be(false) # invalid chars
+      end
+    end
+
+    context 'when LEI format is valid (with or without check-digit)' do
+      it 'returns true' do
+        expect(described_class.valid_format?('5493006MHB84DD0ZWV18')).to be(true)
+        expect(described_class.valid_format?('5493006MHB84DD0ZWV')).to be(true) # missing check-digit
+        expect(described_class.valid_format?('5493006MHB84DD0ZWV99')).to be(true) # wrong check-digit but valid format
+      end
+    end
+  end
+
+  describe '.restore!' do
+    context 'when LEI format is incorrect' do
+      it 'raises an error' do
+        expect { described_class.restore!('INVALID') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.restore!('5493006MHB84DD0ZWV1') }.to raise_error(SecId::InvalidFormatError)
+      end
+    end
+
+    context 'when LEI format is valid' do
+      it 'restores check-digit and returns full LEI' do
+        expect(described_class.restore!('5493006MHB84DD0ZWV')).to eq('5493006MHB84DD0ZWV18')
+        expect(described_class.restore!('5493006MHB84DD0ZWV99')).to eq('5493006MHB84DD0ZWV18')
+        expect(described_class.restore!('529900T8BM49AURSDO')).to eq('529900T8BM49AURSDO55')
+        expect(described_class.restore!('HWUPKR0MPOU8FGXBT3')).to eq('HWUPKR0MPOU8FGXBT394')
+      end
+    end
+  end
+
+  describe '.check_digit' do
+    context 'when LEI format is incorrect' do
+      it 'raises an error' do
+        expect { described_class.check_digit('INVALID') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.check_digit('5493006MHB84DD0ZWV1') }.to raise_error(SecId::InvalidFormatError)
+      end
+    end
+
+    context 'when LEI format is valid' do
+      it 'calculates and returns the check-digit' do
+        expect(described_class.check_digit('5493006MHB84DD0ZWV')).to eq(18)
+        expect(described_class.check_digit('5493006MHB84DD0ZWV18')).to eq(18)
+        expect(described_class.check_digit('529900T8BM49AURSDO')).to eq(55)
+        expect(described_class.check_digit('HWUPKR0MPOU8FGXBT3')).to eq(94)
+        expect(described_class.check_digit('7ZW8QJWVPR4P1J1KQY')).to eq(45)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implement LEI (Legal Entity Identifier) validation and check digit calculation per ISO 17442
- Use MOD 97-10 algorithm (ISO/IEC 7064) for check digit calculation
- Add shared `mod97` helper to Base class for future IBAN reuse
- Parse LEI components: `lou_id`, `reserved`, `entity_id`, `check_digit`
- Add comprehensive test coverage (25 examples)
- Update README with LEI documentation
- Update CHANGELOG

## Test plan

- [x] All 149 tests pass (`bundle exec rspec`)
- [x] No RuboCop offenses (`bundle exec rubocop`)
- [x] Verified with real-world LEI examples:
  - `5493006MHB84DD0ZWV18`
  - `529900T8BM49AURSDO55`
  - `HWUPKR0MPOU8FGXBT394`

Closes #95