### PR TITLE
Add IBAN (International Bank Account Number) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - LEI support (Legal Entity Identifier, ISO 17442)
+- IBAN support (International Bank Account Number, ISO 13616) with EU/EEA country validation
 
 ### Updated
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@
   - [SEDOL](#sedol) - Stock Exchange Daily Official List
   - [FIGI](#figi) - Financial Instrument Global Identifier
   - [LEI](#lei) - Legal Entity Identifier
+  - [IBAN](#iban) - International Bank Account Number
   - [CIK](#cik) - Central Index Key
   - [OCC](#occ) - Options Clearing Corporation Symbol
 - [Development](#development)
 - [Contributing](#contributing)
 - [License](#license)
-
-**Work in progress:** IBAN (International Bank Account Number)
 
 ## Supported Ruby Versions
 
@@ -171,6 +170,34 @@ lei.valid_format?         # => true
 lei.restore!              # => '5493006MHB84DD0ZWV18'
 lei.calculate_check_digit # => 18
 ```
+
+### IBAN
+
+> [International Bank Account Number](https://en.wikipedia.org/wiki/International_Bank_Account_Number) - an internationally standardized system for identifying bank accounts across national borders (ISO 13616).
+
+```ruby
+# class level
+SecId::IBAN.valid?('DE89370400440532013000')       # => true
+SecId::IBAN.valid_format?('DE370400440532013000')  # => true
+SecId::IBAN.restore!('DE370400440532013000')       # => 'DE89370400440532013000'
+SecId::IBAN.check_digit('DE370400440532013000')    # => 89
+
+# instance level
+iban = SecId::IBAN.new('DE89370400440532013000')
+iban.full_number           # => 'DE89370400440532013000'
+iban.country_code          # => 'DE'
+iban.bban                  # => '370400440532013000'
+iban.bank_code             # => '37040044'
+iban.account_number        # => '0532013000'
+iban.check_digit           # => 89
+iban.valid?                # => true
+iban.valid_format?         # => true
+iban.restore!              # => 'DE89370400440532013000'
+iban.calculate_check_digit # => 89
+iban.known_country?        # => true
+```
+
+Full BBAN structural validation is supported for EU/EEA countries. Other countries have length-only validation.
 
 ### CIK
 

--- a/lib/sec_id.rb
+++ b/lib/sec_id.rb
@@ -8,6 +8,7 @@ require 'sec_id/cusip'
 require 'sec_id/sedol'
 require 'sec_id/figi'
 require 'sec_id/lei'
+require 'sec_id/iban'
 require 'sec_id/cik'
 require 'sec_id/occ'
 

--- a/lib/sec_id/iban.rb
+++ b/lib/sec_id/iban.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require_relative 'iban/country_rules'
+
+module SecId
+  # https://en.wikipedia.org/wiki/International_Bank_Account_Number
+  class IBAN < Base
+    include IBANCountryRules
+
+    # IBAN format: 2-letter country code + 2-digit check digits + BBAN (11-30 chars)
+    # Note: Check digits are in positions 3-4, unlike other SecId identifiers where check digit is at the end
+    # The regex captures the full IBAN without check digit positioning logic - we handle that in initialize
+    ID_REGEX = /\A
+      (?<country_code>[A-Z]{2})
+      (?<rest>[A-Z0-9]{13,32})
+    \z/x
+
+    attr_reader :country_code, :bban, :bank_code, :branch_code, :account_number, :national_check
+
+    def initialize(iban)
+      iban_parts = parse(iban)
+      @country_code = iban_parts[:country_code]
+      rest = iban_parts[:rest]
+
+      if @country_code && rest
+        extract_check_digit_and_bban(rest)
+        @identifier = "#{@country_code}#{@bban}" if @bban
+      end
+
+      extract_bban_components if valid_format?
+    end
+
+    def calculate_check_digit
+      unless valid_format?
+        raise InvalidFormatError, "IBAN '#{full_number}' is invalid and check-digit cannot be calculated!"
+      end
+
+      mod97(numeric_string_for_check)
+    end
+
+    def valid_format?
+      return false unless identifier
+
+      valid_bban_format?
+    end
+
+    def valid_bban_format?
+      return false unless bban
+
+      rule = country_rule
+      return valid_bban_length_only? unless rule
+
+      bban.length == rule[:length] && bban.match?(rule[:format])
+    end
+
+    def country_rule
+      COUNTRY_RULES[country_code]
+    end
+
+    def known_country?
+      COUNTRY_RULES.key?(country_code) || LENGTH_ONLY_COUNTRIES.key?(country_code)
+    end
+
+    def to_s
+      return full_number unless check_digit
+
+      "#{country_code}#{check_digit.to_s.rjust(2, '0')}#{bban}"
+    end
+
+    private
+
+    def extract_check_digit_and_bban(rest)
+      expected = expected_bban_length_for_country
+
+      if check_digits?(rest, expected)
+        @check_digit = rest[0, 2].to_i
+        @bban = rest[2..]
+      else
+        @check_digit = nil
+        @bban = rest
+      end
+    end
+
+    def check_digits?(rest, expected_bban_length)
+      return false unless rest[0, 2].match?(/\A\d{2}\z/)
+      return true unless expected_bban_length
+
+      # If we know expected BBAN length, check if rest matches with or without check digits
+      rest.length == expected_bban_length + 2 || rest.length != expected_bban_length
+    end
+
+    def expected_bban_length_for_country
+      COUNTRY_RULES.dig(country_code, :length) || LENGTH_ONLY_COUNTRIES[country_code]
+    end
+
+    def valid_bban_length_only?
+      expected_length = LENGTH_ONLY_COUNTRIES[country_code]
+      return true unless expected_length
+
+      bban.length == expected_length
+    end
+
+    def extract_bban_components
+      rule = country_rule
+      return unless rule&.key?(:components)
+
+      rule[:components].each do |name, (start, length)|
+        instance_variable_set(:"@#{name}", bban[start, length])
+      end
+    end
+
+    # For MOD-97 check: BBAN + country_code + "00" -> convert letters to digits
+    def numeric_string_for_check
+      "#{bban}#{country_code}00".each_char.map { |char| char_to_digit(char) }.join
+    end
+  end
+end

--- a/lib/sec_id/iban/country_rules.rb
+++ b/lib/sec_id/iban/country_rules.rb
@@ -1,0 +1,266 @@
+# frozen_string_literal: true
+
+module SecId
+  # Country-specific BBAN validation rules for IBAN
+  # rubocop:disable Metrics/ModuleLength
+  module IBANCountryRules
+    # Country-specific BBAN rules for EU/EEA countries
+    # Each entry defines:
+    #   - :length => total BBAN length
+    #   - :format => regex pattern for BBAN structure validation
+    #   - :components => hash mapping component names to [start, length] positions
+    #
+    # Sources:
+    # - https://en.wikipedia.org/wiki/International_Bank_Account_Number
+    # - https://www.swift.com/standards/data-standards/iban-international-bank-account-number
+    COUNTRY_RULES = {
+      # Austria - 16 chars: 5-digit bank code + 11-digit account
+      'AT' => {
+        length: 16,
+        format: /\A\d{16}\z/,
+        components: { bank_code: [0, 5], account_number: [5, 11] }
+      },
+      # Belgium - 12 chars: 3-digit bank code + 7-digit account + 2-digit national check
+      'BE' => {
+        length: 12,
+        format: /\A\d{12}\z/,
+        components: { bank_code: [0, 3], account_number: [3, 7], national_check: [10, 2] }
+      },
+      # Bulgaria - 18 chars: 4-letter bank code + 4-digit branch + 2-digit account type + 8-digit account
+      'BG' => {
+        length: 18,
+        format: /\A[A-Z]{4}\d{14}\z/,
+        components: { bank_code: [0, 4], branch_code: [4, 4], account_number: [10, 8] }
+      },
+      # Croatia - 17 chars: 7-digit bank code + 10-digit account
+      'HR' => {
+        length: 17,
+        format: /\A\d{17}\z/,
+        components: { bank_code: [0, 7], account_number: [7, 10] }
+      },
+      # Cyprus - 24 chars: 3-digit bank code + 5-digit branch + 16-char account
+      'CY' => {
+        length: 24,
+        format: /\A\d{8}[A-Z0-9]{16}\z/,
+        components: { bank_code: [0, 3], branch_code: [3, 5], account_number: [8, 16] }
+      },
+      # Czech Republic - 20 chars: 4-digit bank code + 16-digit account
+      'CZ' => {
+        length: 20,
+        format: /\A\d{20}\z/,
+        components: { bank_code: [0, 4], account_number: [4, 16] }
+      },
+      # Denmark - 14 chars: 4-digit bank code + 10-digit account
+      'DK' => {
+        length: 14,
+        format: /\A\d{14}\z/,
+        components: { bank_code: [0, 4], account_number: [4, 10] }
+      },
+      # Estonia - 16 chars: 2-digit bank code + 14-digit account
+      'EE' => {
+        length: 16,
+        format: /\A\d{16}\z/,
+        components: { bank_code: [0, 2], account_number: [2, 14] }
+      },
+      # Finland - 14 chars: 3-digit bank code + 11-digit account
+      'FI' => {
+        length: 14,
+        format: /\A\d{14}\z/,
+        components: { bank_code: [0, 3], account_number: [3, 11] }
+      },
+      # France - 23 chars: 5-digit bank + 5-digit branch + 11-char account + 2-digit national check
+      'FR' => {
+        length: 23,
+        format: /\A\d{10}[A-Z0-9]{11}\d{2}\z/,
+        components: { bank_code: [0, 5], branch_code: [5, 5], account_number: [10, 11], national_check: [21, 2] }
+      },
+      # Germany - 18 chars: 8-digit bank code (Bankleitzahl) + 10-digit account
+      'DE' => {
+        length: 18,
+        format: /\A\d{18}\z/,
+        components: { bank_code: [0, 8], account_number: [8, 10] }
+      },
+      # Greece - 23 chars: 3-digit bank code + 4-digit branch + 16-digit account
+      'GR' => {
+        length: 23,
+        format: /\A\d{23}\z/,
+        components: { bank_code: [0, 3], branch_code: [3, 4], account_number: [7, 16] }
+      },
+      # Hungary - 24 chars: 3-digit bank code + 4-digit branch + 16-digit account + 1-digit national check
+      'HU' => {
+        length: 24,
+        format: /\A\d{24}\z/,
+        components: { bank_code: [0, 3], branch_code: [3, 4], account_number: [7, 16], national_check: [23, 1] }
+      },
+      # Iceland - 22 chars: 4-digit bank code + 2-digit branch + 6-digit account + 10-digit holder ID
+      'IS' => {
+        length: 22,
+        format: /\A\d{22}\z/,
+        components: { bank_code: [0, 4], branch_code: [4, 2], account_number: [6, 6] }
+      },
+      # Ireland - 18 chars: 4-letter bank code + 6-digit branch + 8-digit account
+      'IE' => {
+        length: 18,
+        format: /\A[A-Z]{4}\d{14}\z/,
+        components: { bank_code: [0, 4], branch_code: [4, 6], account_number: [10, 8] }
+      },
+      # Italy - 23 chars: 1-letter check + 5-digit bank code + 5-digit branch + 12-char account
+      'IT' => {
+        length: 23,
+        format: /\A[A-Z]\d{10}[A-Z0-9]{12}\z/,
+        components: { national_check: [0, 1], bank_code: [1, 5], branch_code: [6, 5], account_number: [11, 12] }
+      },
+      # Latvia - 17 chars: 4-letter bank code + 13-digit account
+      'LV' => {
+        length: 17,
+        format: /\A[A-Z]{4}[A-Z0-9]{13}\z/,
+        components: { bank_code: [0, 4], account_number: [4, 13] }
+      },
+      # Liechtenstein - 17 chars: 5-digit bank code + 12-char account
+      'LI' => {
+        length: 17,
+        format: /\A\d{5}[A-Z0-9]{12}\z/,
+        components: { bank_code: [0, 5], account_number: [5, 12] }
+      },
+      # Lithuania - 16 chars: 5-digit bank code + 11-digit account
+      'LT' => {
+        length: 16,
+        format: /\A\d{16}\z/,
+        components: { bank_code: [0, 5], account_number: [5, 11] }
+      },
+      # Luxembourg - 16 chars: 3-digit bank code + 13-char account
+      'LU' => {
+        length: 16,
+        format: /\A\d{3}[A-Z0-9]{13}\z/,
+        components: { bank_code: [0, 3], account_number: [3, 13] }
+      },
+      # Malta - 27 chars: 4-letter bank code + 5-digit branch + 18-char account
+      'MT' => {
+        length: 27,
+        format: /\A[A-Z]{4}\d{5}[A-Z0-9]{18}\z/,
+        components: { bank_code: [0, 4], branch_code: [4, 5], account_number: [9, 18] }
+      },
+      # Monaco - 23 chars: same format as France
+      'MC' => {
+        length: 23,
+        format: /\A\d{10}[A-Z0-9]{11}\d{2}\z/,
+        components: { bank_code: [0, 5], branch_code: [5, 5], account_number: [10, 11], national_check: [21, 2] }
+      },
+      # Netherlands - 14 chars: 4-letter bank code + 10-digit account
+      'NL' => {
+        length: 14,
+        format: /\A[A-Z]{4}\d{10}\z/,
+        components: { bank_code: [0, 4], account_number: [4, 10] }
+      },
+      # Norway - 11 chars: 4-digit bank code + 6-digit account + 1-digit national check
+      'NO' => {
+        length: 11,
+        format: /\A\d{11}\z/,
+        components: { bank_code: [0, 4], account_number: [4, 6], national_check: [10, 1] }
+      },
+      # Poland - 24 chars: 3-digit bank code + 4-digit branch + 1-digit check + 16-digit account
+      'PL' => {
+        length: 24,
+        format: /\A\d{24}\z/,
+        components: { bank_code: [0, 3], branch_code: [3, 4], national_check: [7, 1], account_number: [8, 16] }
+      },
+      # Portugal - 21 chars: 4-digit bank code + 4-digit branch + 11-digit account + 2-digit national check
+      'PT' => {
+        length: 21,
+        format: /\A\d{21}\z/,
+        components: { bank_code: [0, 4], branch_code: [4, 4], account_number: [8, 11], national_check: [19, 2] }
+      },
+      # Romania - 20 chars: 4-letter bank code + 16-char account
+      'RO' => {
+        length: 20,
+        format: /\A[A-Z]{4}[A-Z0-9]{16}\z/,
+        components: { bank_code: [0, 4], account_number: [4, 16] }
+      },
+      # San Marino - 23 chars: same format as Italy
+      'SM' => {
+        length: 23,
+        format: /\A[A-Z]\d{10}[A-Z0-9]{12}\z/,
+        components: { national_check: [0, 1], bank_code: [1, 5], branch_code: [6, 5], account_number: [11, 12] }
+      },
+      # Slovakia - 20 chars: 4-digit bank code + 16-digit account
+      'SK' => {
+        length: 20,
+        format: /\A\d{20}\z/,
+        components: { bank_code: [0, 4], account_number: [4, 16] }
+      },
+      # Slovenia - 15 chars: 5-digit bank code + 8-digit account + 2-digit national check
+      'SI' => {
+        length: 15,
+        format: /\A\d{15}\z/,
+        components: { bank_code: [0, 5], account_number: [5, 8], national_check: [13, 2] }
+      },
+      # Spain - 20 chars: 4-digit bank code + 4-digit branch + 2-digit national check + 10-digit account
+      'ES' => {
+        length: 20,
+        format: /\A\d{20}\z/,
+        components: { bank_code: [0, 4], branch_code: [4, 4], national_check: [8, 2], account_number: [10, 10] }
+      },
+      # Sweden - 20 chars: 3-digit bank code + 17-digit account
+      'SE' => {
+        length: 20,
+        format: /\A\d{20}\z/,
+        components: { bank_code: [0, 3], account_number: [3, 17] }
+      },
+      # Switzerland - 17 chars: 5-digit bank code + 12-char account
+      'CH' => {
+        length: 17,
+        format: /\A\d{5}[A-Z0-9]{12}\z/,
+        components: { bank_code: [0, 5], account_number: [5, 12] }
+      },
+      # United Kingdom - 18 chars: 4-letter bank code + 6-digit branch (sort code) + 8-digit account
+      'GB' => {
+        length: 18,
+        format: /\A[A-Z]{4}\d{14}\z/,
+        components: { bank_code: [0, 4], branch_code: [4, 6], account_number: [10, 8] }
+      }
+    }.freeze
+
+    # Countries where only length validation is performed (non-EU/EEA countries)
+    # Format: country_code => expected BBAN length
+    LENGTH_ONLY_COUNTRIES = {
+      'AD' => 20, # Andorra
+      'AE' => 19, # UAE
+      'AL' => 24, # Albania
+      'AZ' => 24, # Azerbaijan
+      'BA' => 16, # Bosnia and Herzegovina
+      'BY' => 24, # Belarus
+      'DO' => 24, # Dominican Republic
+      'EG' => 25, # Egypt
+      'GE' => 18, # Georgia
+      'GI' => 19, # Gibraltar
+      'GT' => 24, # Guatemala
+      'IL' => 19, # Israel
+      'IQ' => 19, # Iraq
+      'JO' => 26, # Jordan
+      'KW' => 26, # Kuwait
+      'KZ' => 16, # Kazakhstan
+      'LB' => 24, # Lebanon
+      'LC' => 28, # Saint Lucia
+      'MD' => 20, # Moldova
+      'ME' => 18, # Montenegro
+      'MK' => 15, # North Macedonia
+      'MR' => 23, # Mauritania
+      'MU' => 26, # Mauritius
+      'PS' => 25, # Palestine
+      'QA' => 25, # Qatar
+      'RS' => 18, # Serbia
+      'SA' => 20, # Saudi Arabia
+      'SC' => 27, # Seychelles
+      'ST' => 21, # Sao Tome and Principe
+      'SV' => 24, # El Salvador
+      'TL' => 19, # Timor-Leste
+      'TN' => 20, # Tunisia
+      'TR' => 22, # Turkey
+      'UA' => 25, # Ukraine
+      'VA' => 18, # Vatican City
+      'VG' => 20, # British Virgin Islands
+      'XK' => 16  # Kosovo
+    }.freeze
+  end
+  # rubocop:enable Metrics/ModuleLength
+end

--- a/sec_id.gemspec
+++ b/sec_id.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Validate securities identification numbers with ease!'
   spec.description   = 'Validate, calculate check digits, and parse components of securities identifiers. ' \
-                       'Supports ISIN, CUSIP, SEDOL, FIGI, LEI, CIK, and OCC standards.'
+                       'Supports ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CIK, and OCC standards.'
   spec.homepage      = 'https://github.com/svyatov/sec_id'
   spec.license       = 'MIT'
 

--- a/spec/sec_id/iban_spec.rb
+++ b/spec/sec_id/iban_spec.rb
@@ -1,0 +1,581 @@
+# frozen_string_literal: true
+
+RSpec.describe SecId::IBAN do
+  let(:iban) { described_class.new(iban_number) }
+
+  context 'when IBAN is valid (Germany)' do
+    let(:iban_number) { 'DE89370400440532013000' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('DE')
+      expect(iban.check_digit).to eq(89)
+      expect(iban.bban).to eq('370400440532013000')
+      expect(iban.identifier).to eq('DE370400440532013000')
+    end
+
+    it 'extracts BBAN components' do
+      expect(iban.bank_code).to eq('37040044')
+      expect(iban.account_number).to eq('0532013000')
+      expect(iban.branch_code).to be_nil
+      expect(iban.national_check).to be_nil
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(iban.valid?).to be(true)
+      end
+    end
+
+    describe '#restore!' do
+      it 'restores check-digit and returns full IBAN' do
+        expect(iban.restore!).to eq(iban_number)
+        expect(iban.full_number).to eq(iban_number)
+      end
+    end
+
+    describe '#to_s' do
+      it 'returns full IBAN' do
+        expect(iban.to_s).to eq(iban_number)
+      end
+    end
+
+    describe '#known_country?' do
+      it 'returns true' do
+        expect(iban.known_country?).to be(true)
+      end
+    end
+  end
+
+  context 'when IBAN is valid (France)' do
+    let(:iban_number) { 'FR1420041010050500013M02606' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('FR')
+      expect(iban.check_digit).to eq(14)
+      expect(iban.bban).to eq('20041010050500013M02606')
+    end
+
+    it 'extracts BBAN components' do
+      expect(iban.bank_code).to eq('20041')
+      expect(iban.branch_code).to eq('01005')
+      expect(iban.account_number).to eq('0500013M026')
+      expect(iban.national_check).to eq('06')
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(iban.valid?).to be(true)
+      end
+    end
+  end
+
+  context 'when IBAN is valid (United Kingdom)' do
+    let(:iban_number) { 'GB29NWBK60161331926819' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('GB')
+      expect(iban.check_digit).to eq(29)
+      expect(iban.bban).to eq('NWBK60161331926819')
+    end
+
+    it 'extracts BBAN components' do
+      expect(iban.bank_code).to eq('NWBK')
+      expect(iban.branch_code).to eq('601613')
+      expect(iban.account_number).to eq('31926819')
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(iban.valid?).to be(true)
+      end
+    end
+  end
+
+  context 'when IBAN is valid (Spain)' do
+    let(:iban_number) { 'ES9121000418450200051332' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('ES')
+      expect(iban.check_digit).to eq(91)
+      expect(iban.bban).to eq('21000418450200051332')
+    end
+
+    it 'extracts BBAN components' do
+      expect(iban.bank_code).to eq('2100')
+      expect(iban.branch_code).to eq('0418')
+      expect(iban.national_check).to eq('45')
+      expect(iban.account_number).to eq('0200051332')
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(iban.valid?).to be(true)
+      end
+    end
+  end
+
+  context 'when IBAN is valid (Netherlands)' do
+    let(:iban_number) { 'NL91ABNA0417164300' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('NL')
+      expect(iban.check_digit).to eq(91)
+      expect(iban.bban).to eq('ABNA0417164300')
+    end
+
+    it 'extracts BBAN components' do
+      expect(iban.bank_code).to eq('ABNA')
+      expect(iban.account_number).to eq('0417164300')
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(iban.valid?).to be(true)
+      end
+    end
+  end
+
+  context 'when IBAN is valid (Belgium)' do
+    let(:iban_number) { 'BE68539007547034' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('BE')
+      expect(iban.check_digit).to eq(68)
+      expect(iban.bban).to eq('539007547034')
+    end
+
+    it 'extracts BBAN components' do
+      expect(iban.bank_code).to eq('539')
+      expect(iban.account_number).to eq('0075470')
+      expect(iban.national_check).to eq('34')
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(iban.valid?).to be(true)
+      end
+    end
+  end
+
+  context 'when IBAN is valid (Italy)' do
+    let(:iban_number) { 'IT60X0542811101000000123456' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('IT')
+      expect(iban.check_digit).to eq(60)
+      expect(iban.bban).to eq('X0542811101000000123456')
+    end
+
+    it 'extracts BBAN components' do
+      expect(iban.national_check).to eq('X')
+      expect(iban.bank_code).to eq('05428')
+      expect(iban.branch_code).to eq('11101')
+      expect(iban.account_number).to eq('000000123456')
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(iban.valid?).to be(true)
+      end
+    end
+  end
+
+  context 'when IBAN is valid (Switzerland)' do
+    let(:iban_number) { 'CH9300762011623852957' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('CH')
+      expect(iban.check_digit).to eq(93)
+      expect(iban.bban).to eq('00762011623852957')
+    end
+
+    it 'extracts BBAN components' do
+      expect(iban.bank_code).to eq('00762')
+      expect(iban.account_number).to eq('011623852957')
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(iban.valid?).to be(true)
+      end
+    end
+  end
+
+  context 'when IBAN is valid (Austria)' do
+    let(:iban_number) { 'AT611904300234573201' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('AT')
+      expect(iban.check_digit).to eq(61)
+      expect(iban.bban).to eq('1904300234573201')
+    end
+
+    it 'extracts BBAN components' do
+      expect(iban.bank_code).to eq('19043')
+      expect(iban.account_number).to eq('00234573201')
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(iban.valid?).to be(true)
+      end
+    end
+  end
+
+  context 'when IBAN has invalid check-digit' do
+    let(:iban_number) { 'DE99370400440532013000' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('DE')
+      expect(iban.check_digit).to eq(99)
+      expect(iban.bban).to eq('370400440532013000')
+    end
+
+    describe '#valid?' do
+      it 'returns false' do
+        expect(iban.valid?).to be(false)
+      end
+    end
+
+    describe '#restore!' do
+      it 'restores check-digit and returns corrected IBAN' do
+        expect(iban.restore!).to eq('DE89370400440532013000')
+        expect(iban.full_number).to eq('DE89370400440532013000')
+      end
+    end
+  end
+
+  context 'when IBAN is missing check-digit' do
+    let(:iban_number) { 'DE370400440532013000' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('DE')
+      expect(iban.bban).to eq('370400440532013000')
+      expect(iban.check_digit).to be_nil
+    end
+
+    describe '#valid?' do
+      it 'returns false' do
+        expect(iban.valid?).to be(false)
+      end
+    end
+
+    describe '#restore!' do
+      it 'restores check-digit and returns full IBAN' do
+        expect(iban.restore!).to eq('DE89370400440532013000')
+        expect(iban.full_number).to eq('DE89370400440532013000')
+      end
+    end
+  end
+
+  context 'when IBAN format is invalid' do
+    let(:iban_number) { 'INVALID' }
+
+    it 'parses IBAN as nil' do
+      expect(iban.country_code).to be_nil
+      expect(iban.bban).to be_nil
+      expect(iban.check_digit).to be_nil
+      expect(iban.identifier).to be_nil
+    end
+
+    describe '#valid?' do
+      it 'returns false' do
+        expect(iban.valid?).to be(false)
+      end
+    end
+
+    describe '#restore!' do
+      it 'raises an error' do
+        expect { iban.restore! }.to raise_error(SecId::InvalidFormatError)
+      end
+    end
+  end
+
+  context 'when IBAN has invalid BBAN length for country' do
+    let(:iban_number) { 'DE8937040044053201' } # 16 chars instead of 18
+
+    it 'parses country code and BBAN' do
+      expect(iban.country_code).to eq('DE')
+      expect(iban.bban).to eq('37040044053201')
+    end
+
+    describe '#valid?' do
+      it 'returns false' do
+        expect(iban.valid?).to be(false)
+      end
+    end
+
+    describe '#valid_format?' do
+      it 'returns false' do
+        expect(iban.valid_format?).to be(false)
+      end
+    end
+
+    describe '#valid_bban_format?' do
+      it 'returns false' do
+        expect(iban.valid_bban_format?).to be(false)
+      end
+    end
+  end
+
+  context 'when IBAN has invalid BBAN format for country' do
+    let(:iban_number) { 'DE89ABCD00440532013000' } # Letters in BBAN for DE (should be all digits)
+
+    it 'parses country code and BBAN' do
+      expect(iban.country_code).to eq('DE')
+      expect(iban.bban).to eq('ABCD00440532013000')
+    end
+
+    describe '#valid_format?' do
+      it 'returns false' do
+        expect(iban.valid_format?).to be(false)
+      end
+    end
+  end
+
+  context 'when IBAN contains lowercase letters' do
+    let(:iban_number) { 'de89370400440532013000' }
+
+    it 'normalizes to uppercase and parses correctly' do
+      expect(iban.country_code).to eq('DE')
+      expect(iban.check_digit).to eq(89)
+      expect(iban.bban).to eq('370400440532013000')
+      expect(iban.valid?).to be(true)
+    end
+  end
+
+  context 'when IBAN is from length-only validated country (Saudi Arabia)' do
+    let(:iban_number) { 'SA0380000000608010167519' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('SA')
+      expect(iban.check_digit).to eq(3)
+      expect(iban.bban).to eq('80000000608010167519')
+    end
+
+    it 'does not extract BBAN components' do
+      expect(iban.bank_code).to be_nil
+      expect(iban.account_number).to be_nil
+    end
+
+    describe '#valid?' do
+      it 'returns true' do
+        expect(iban.valid?).to be(true)
+      end
+    end
+
+    describe '#known_country?' do
+      it 'returns true' do
+        expect(iban.known_country?).to be(true)
+      end
+    end
+  end
+
+  context 'when IBAN is from unknown country' do
+    let(:iban_number) { 'XX00123456789012345' }
+
+    it 'parses IBAN correctly' do
+      expect(iban.country_code).to eq('XX')
+      expect(iban.bban).to eq('123456789012345')
+    end
+
+    describe '#known_country?' do
+      it 'returns false' do
+        expect(iban.known_country?).to be(false)
+      end
+    end
+
+    describe '#valid_format?' do
+      it 'returns true for unknown countries (lenient mode)' do
+        expect(iban.valid_format?).to be(true)
+      end
+    end
+  end
+
+  describe '.valid?' do
+    context 'when IBAN is incorrect' do
+      it 'returns false' do
+        expect(described_class.valid?('INVALID')).to be(false)
+        expect(described_class.valid?('DE370400440532013000')).to be(false) # missing check-digit
+        expect(described_class.valid?('DE99370400440532013000')).to be(false) # wrong check-digit
+        expect(described_class.valid?('DE8937040044053201')).to be(false) # too short BBAN
+      end
+    end
+
+    context 'when IBAN is valid' do
+      # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+      it 'returns true for real-world examples from various countries' do
+        expect(described_class.valid?('DE89370400440532013000')).to be(true) # Germany
+        expect(described_class.valid?('FR1420041010050500013M02606')).to be(true) # France
+        expect(described_class.valid?('GB29NWBK60161331926819')).to be(true) # UK
+        expect(described_class.valid?('ES9121000418450200051332')).to be(true) # Spain
+        expect(described_class.valid?('NL91ABNA0417164300')).to be(true) # Netherlands
+        expect(described_class.valid?('BE68539007547034')).to be(true) # Belgium
+        expect(described_class.valid?('IT60X0542811101000000123456')).to be(true) # Italy
+        expect(described_class.valid?('CH9300762011623852957')).to be(true) # Switzerland
+        expect(described_class.valid?('AT611904300234573201')).to be(true) # Austria
+        expect(described_class.valid?('PL61109010140000071219812874')).to be(true) # Poland
+        expect(described_class.valid?('SE4550000000058398257466')).to be(true) # Sweden
+        expect(described_class.valid?('NO9386011117947')).to be(true) # Norway
+        expect(described_class.valid?('DK5000400440116243')).to be(true) # Denmark
+        expect(described_class.valid?('FI2112345600000785')).to be(true) # Finland
+        expect(described_class.valid?('PT50000201231234567890154')).to be(true) # Portugal
+        expect(described_class.valid?('IE29AIBK93115212345678')).to be(true) # Ireland
+      end
+      # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
+    end
+  end
+
+  describe '.valid_format?' do
+    context 'when IBAN format is incorrect' do
+      it 'returns false' do
+        expect(described_class.valid_format?('INVALID')).to be(false)
+        expect(described_class.valid_format?('DE8937040044053201')).to be(false) # too short BBAN
+        expect(described_class.valid_format?('DE89370400440532013000!')).to be(false) # invalid char
+      end
+    end
+
+    context 'when IBAN format is valid (with or without check-digit)' do
+      it 'returns true' do
+        expect(described_class.valid_format?('DE89370400440532013000')).to be(true)
+        expect(described_class.valid_format?('DE370400440532013000')).to be(true) # missing check-digit
+        expect(described_class.valid_format?('DE99370400440532013000')).to be(true) # wrong check-digit but valid format
+      end
+    end
+  end
+
+  describe '.restore!' do
+    context 'when IBAN format is incorrect' do
+      it 'raises an error' do
+        expect { described_class.restore!('INVALID') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.restore!('DE8937040044053201') }.to raise_error(SecId::InvalidFormatError)
+      end
+    end
+
+    context 'when IBAN format is valid' do
+      it 'restores check-digit and returns full IBAN' do
+        expect(described_class.restore!('DE370400440532013000')).to eq('DE89370400440532013000')
+        expect(described_class.restore!('DE99370400440532013000')).to eq('DE89370400440532013000')
+        expect(described_class.restore!('NLABNA0417164300')).to eq('NL91ABNA0417164300')
+        expect(described_class.restore!('GB29NWBK60161331926819')).to eq('GB29NWBK60161331926819')
+      end
+    end
+  end
+
+  describe '.check_digit' do
+    context 'when IBAN format is incorrect' do
+      it 'raises an error' do
+        expect { described_class.check_digit('INVALID') }.to raise_error(SecId::InvalidFormatError)
+        expect { described_class.check_digit('DE8937040044053201') }.to raise_error(SecId::InvalidFormatError)
+      end
+    end
+
+    context 'when IBAN format is valid' do
+      it 'calculates and returns the check-digit' do
+        expect(described_class.check_digit('DE370400440532013000')).to eq(89)
+        expect(described_class.check_digit('DE89370400440532013000')).to eq(89)
+        expect(described_class.check_digit('GBNWBK60161331926819')).to eq(29)
+        expect(described_class.check_digit('ES21000418450200051332')).to eq(91)
+        expect(described_class.check_digit('NL91ABNA0417164300')).to eq(91)
+      end
+    end
+  end
+
+  describe '#country_rule' do
+    context 'when country has explicit rules' do
+      let(:iban_number) { 'DE89370400440532013000' }
+
+      it 'returns the country rule hash' do
+        expect(iban.country_rule).to be_a(Hash)
+        expect(iban.country_rule[:length]).to eq(18)
+        expect(iban.country_rule[:format]).to eq(/\A\d{18}\z/)
+        expect(iban.country_rule[:components]).to include(:bank_code, :account_number)
+      end
+    end
+
+    context 'when country has length-only validation' do
+      let(:iban_number) { 'SA0380000000608010167519' }
+
+      it 'returns nil' do
+        expect(iban.country_rule).to be_nil
+      end
+    end
+  end
+
+  # Test additional EU/EEA countries for structural validation
+  describe 'EU/EEA country validation' do
+    {
+      'AT' => { iban: 'AT611904300234573201', length: 16 },
+      'BE' => { iban: 'BE68539007547034', length: 12 },
+      'BG' => { iban: 'BG80BNBG96611020345678', length: 18 },
+      'CH' => { iban: 'CH9300762011623852957', length: 17 },
+      'CY' => { iban: 'CY17002001280000001200527600', length: 24 },
+      'CZ' => { iban: 'CZ6508000000192000145399', length: 20 },
+      'DE' => { iban: 'DE89370400440532013000', length: 18 },
+      'DK' => { iban: 'DK5000400440116243', length: 14 },
+      'EE' => { iban: 'EE382200221020145685', length: 16 },
+      'ES' => { iban: 'ES9121000418450200051332', length: 20 },
+      'FI' => { iban: 'FI2112345600000785', length: 14 },
+      'FR' => { iban: 'FR1420041010050500013M02606', length: 23 },
+      'GB' => { iban: 'GB29NWBK60161331926819', length: 18 },
+      'GR' => { iban: 'GR1601101250000000012300695', length: 23 },
+      'HR' => { iban: 'HR1210010051863000160', length: 17 },
+      'HU' => { iban: 'HU42117730161111101800000000', length: 24 },
+      'IE' => { iban: 'IE29AIBK93115212345678', length: 18 },
+      'IS' => { iban: 'IS140159260076545510730339', length: 22 },
+      'IT' => { iban: 'IT60X0542811101000000123456', length: 23 },
+      'LI' => { iban: 'LI21088100002324013AA', length: 17 },
+      'LT' => { iban: 'LT121000011101001000', length: 16 },
+      'LU' => { iban: 'LU280019400644750000', length: 16 },
+      'LV' => { iban: 'LV80BANK0000435195001', length: 17 },
+      'MC' => { iban: 'MC5811222000010123456789030', length: 23 },
+      'MT' => { iban: 'MT84MALT011000012345MTLCAST001S', length: 27 },
+      'NL' => { iban: 'NL91ABNA0417164300', length: 14 },
+      'NO' => { iban: 'NO9386011117947', length: 11 },
+      'PL' => { iban: 'PL61109010140000071219812874', length: 24 },
+      'PT' => { iban: 'PT50000201231234567890154', length: 21 },
+      'RO' => { iban: 'RO49AAAA1B31007593840000', length: 20 },
+      'SE' => { iban: 'SE4550000000058398257466', length: 20 },
+      'SI' => { iban: 'SI56263300012039086', length: 15 },
+      'SK' => { iban: 'SK3112000000198742637541', length: 20 },
+      'SM' => { iban: 'SM86U0322509800000000270100', length: 23 }
+    }.each do |country, data|
+      context "when IBAN is from #{country}" do
+        let(:iban_number) { data[:iban] }
+
+        it 'validates correctly' do
+          expect(iban.valid?).to be(true), "Expected #{country} IBAN #{data[:iban]} to be valid"
+        end
+
+        it "has BBAN length of #{data[:length]}" do
+          expect(iban.bban.length).to eq(data[:length])
+        end
+      end
+    end
+  end
+
+  # Test length-only countries
+  describe 'length-only country validation' do
+    {
+      'SA' => { iban: 'SA0380000000608010167519', length: 20 },
+      'AE' => { iban: 'AE070331234567890123456', length: 19 },
+      'TR' => { iban: 'TR330006100519786457841326', length: 22 }
+    }.each do |country, data|
+      context "when IBAN is from #{country}" do
+        let(:iban_number) { data[:iban] }
+
+        it 'validates correctly' do
+          expect(iban.valid?).to be(true), "Expected #{country} IBAN #{data[:iban]} to be valid"
+        end
+
+        it 'is a known country' do
+          expect(iban.known_country?).to be(true)
+        end
+
+        it 'does not extract BBAN components' do
+          expect(iban.bank_code).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implements IBAN validation with MOD-97-10 check digit algorithm (ISO 13616)
- Full BBAN structural validation for 35 EU/EEA countries
- Length-only validation for 37 additional countries  
- BBAN component extraction (bank_code, branch_code, account_number, national_check)
- Comprehensive test suite with 140 test cases

## Test plan

- [x] All 289 tests pass (140 new IBAN tests + 149 existing)
- [x] No RuboCop offenses
- [x] Verified with real-world IBAN examples from multiple countries
- [x] README updated with usage examples
- [x] CHANGELOG updated

Closes #96