### PR TITLE
feat: add CFI (Classification of Financial Instruments) support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,10 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
+Metrics/ClassLength:
+  Exclude:
+    - 'lib/sec_id/cfi.rb'
+
 Lint/MissingSuper:
   AllowedParentClasses:
     - Base

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ### Added
 
+- CFI (Classification of Financial Instruments) support with category/group validation and equity-specific predicates
 - Valoren support (Swiss Security Number) ([@wtn](https://github.com/wtn), [#109](https://github.com/svyatov/sec_id/pull/109))
 - WKN support (Wertpapierkennnummer - German securities identifier) ([@wtn](https://github.com/wtn), [#108](https://github.com/svyatov/sec_id/pull/108))
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Architecture
 
-This is a Ruby gem for validating securities identification numbers (ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren).
+This is a Ruby gem for validating securities identification numbers (ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren, CFI).
 
 ### Class Hierarchy
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - [OCC](#occ) - Options Clearing Corporation Symbol
   - [WKN](#wkn) - Wertpapierkennnummer
   - [Valoren](#valoren) - Swiss Security Number
+  - [CFI](#cfi) - Classification of Financial Instruments
 - [Development](#development)
 - [Contributing](#contributing)
 - [Changelog](#changelog)
@@ -307,6 +308,37 @@ valoren.valid_format? # => true
 valoren.normalize!    # => '003886335'
 valoren.to_s          # => '003886335'
 ```
+
+### CFI
+
+> [Classification of Financial Instruments](https://en.wikipedia.org/wiki/ISO_10962) - a 6-character alphabetic code that classifies financial instruments per ISO 10962.
+
+```ruby
+# class level
+SecId::CFI.valid?('ESXXXX')        # => true
+SecId::CFI.valid?('ESVUFR')        # => true
+SecId::CFI.valid_format?('ESXXXX') # => true
+
+# instance level
+cfi = SecId::CFI.new('ESVUFR')
+cfi.full_number    # => 'ESVUFR'
+cfi.identifier     # => 'ESVUFR'
+cfi.category_code  # => 'E'
+cfi.group_code     # => 'S'
+cfi.category       # => :equity
+cfi.group          # => :common_shares
+cfi.valid?         # => true
+cfi.valid_format?  # => true
+
+# Equity-specific predicates
+cfi.equity?        # => true
+cfi.voting?        # => true
+cfi.restrictions?  # => false
+cfi.fully_paid?    # => true
+cfi.registered?    # => true
+```
+
+CFI validates the category code (position 1) against 14 valid values and the group code (position 2) against valid values for that category. Attribute positions 3-6 accept any letter A-Z, with X meaning "not applicable".
 
 ## Development
 

--- a/lib/sec_id.rb
+++ b/lib/sec_id.rb
@@ -14,6 +14,7 @@ require 'sec_id/cik'
 require 'sec_id/occ'
 require 'sec_id/wkn'
 require 'sec_id/valoren'
+require 'sec_id/cfi'
 
 module SecId
   Error = Class.new(StandardError)

--- a/lib/sec_id/cfi.rb
+++ b/lib/sec_id/cfi.rb
@@ -1,0 +1,320 @@
+# frozen_string_literal: true
+
+module SecId
+  # Classification of Financial Instruments (CFI) - a 6-character alphabetic code
+  # that classifies financial instruments per ISO 10962.
+  #
+  # Format: 6 uppercase letters A-Z
+  # - Position 1: Category code (14 valid values)
+  # - Position 2: Group code (varies by category)
+  # - Positions 3-6: Attribute codes (A-Z, with X meaning "not applicable")
+  #
+  # @see https://en.wikipedia.org/wiki/ISO_10962
+  #
+  # @example Validate a CFI code
+  #   SecId::CFI.valid?('ESXXXX')  #=> true
+  #   SecId::CFI.valid?('ESVUFR')  #=> true
+  #
+  # @example Access CFI components
+  #   cfi = SecId::CFI.new('ESVUFR')
+  #   cfi.category        #=> :equity
+  #   cfi.group           #=> :common_shares
+  #   cfi.voting?         #=> true
+  class CFI < Base
+    # Regular expression for parsing CFI components.
+    ID_REGEX = /\A
+      (?<identifier>
+        (?<category_code>[A-Z])
+        (?<group_code>[A-Z])
+        (?<attr1>[A-Z])
+        (?<attr2>[A-Z])
+        (?<attr3>[A-Z])
+        (?<attr4>[A-Z]))
+    \z/x
+
+    # Category codes per ISO 10962.
+    CATEGORIES = {
+      'E' => :equity,
+      'C' => :collective_investment_vehicles,
+      'D' => :debt_instruments,
+      'R' => :entitlements,
+      'O' => :listed_options,
+      'F' => :futures,
+      'S' => :swaps,
+      'H' => :non_listed_options,
+      'I' => :spot,
+      'J' => :forwards,
+      'K' => :strategies,
+      'L' => :financing,
+      'T' => :referential_instruments,
+      'M' => :miscellaneous
+    }.freeze
+
+    # Group codes per category per ISO 10962.
+    GROUPS = {
+      'E' => { # Equity
+        'S' => :common_shares,
+        'P' => :preferred_shares,
+        'C' => :convertible_common_shares,
+        'F' => :convertible_preferred_shares,
+        'L' => :limited_partnership_units,
+        'D' => :depositary_receipts,
+        'Y' => :structured_instruments,
+        'M' => :miscellaneous
+      },
+      'C' => { # Collective Investment Vehicles
+        'I' => :standard_investment_funds,
+        'H' => :hedge_funds,
+        'B' => :real_estate_investment_trusts,
+        'E' => :exchange_traded_funds,
+        'S' => :pension_funds,
+        'F' => :funds_of_funds,
+        'P' => :private_equity_funds,
+        'M' => :miscellaneous
+      },
+      'D' => { # Debt Instruments
+        'B' => :bonds,
+        'C' => :convertible_bonds,
+        'W' => :bonds_with_warrants,
+        'T' => :medium_term_notes,
+        'Y' => :money_market_instruments,
+        'S' => :structured_instruments,
+        'E' => :mortgage_backed_securities,
+        'G' => :asset_backed_securities,
+        'A' => :municipal_bonds,
+        'N' => :municipal_notes,
+        'D' => :depositary_receipts,
+        'M' => :miscellaneous
+      },
+      'R' => { # Entitlements (Rights)
+        'A' => :allotment_rights,
+        'S' => :subscription_rights,
+        'P' => :purchase_rights,
+        'W' => :warrants,
+        'F' => :mini_future_certificates,
+        'D' => :depositary_receipts,
+        'M' => :miscellaneous
+      },
+      'O' => { # Listed Options
+        'C' => :call_options,
+        'P' => :put_options,
+        'M' => :miscellaneous
+      },
+      'F' => { # Futures
+        'F' => :financial_futures,
+        'C' => :commodities_futures,
+        'M' => :miscellaneous
+      },
+      'S' => { # Swaps
+        'R' => :rates,
+        'T' => :commodities,
+        'E' => :equity,
+        'C' => :credit,
+        'F' => :foreign_exchange,
+        'M' => :miscellaneous
+      },
+      'H' => { # Non-Listed (Complex) Options
+        'C' => :call_options,
+        'P' => :put_options,
+        'M' => :miscellaneous
+      },
+      'I' => { # Spot
+        'F' => :foreign_exchange,
+        'T' => :commodities,
+        'M' => :miscellaneous
+      },
+      'J' => { # Forwards
+        'F' => :foreign_exchange,
+        'R' => :rates,
+        'T' => :commodities,
+        'E' => :equity,
+        'C' => :credit,
+        'M' => :miscellaneous
+      },
+      'K' => { # Strategies
+        'R' => :rates,
+        'T' => :commodities,
+        'E' => :equity,
+        'C' => :credit,
+        'F' => :foreign_exchange,
+        'Y' => :mixed,
+        'M' => :miscellaneous
+      },
+      'L' => { # Financing
+        'S' => :loan_lease,
+        'R' => :repurchase_agreements,
+        'P' => :securities_lending,
+        'M' => :miscellaneous
+      },
+      'T' => { # Referential Instruments
+        'I' => :currencies,
+        'C' => :commodities,
+        'R' => :interest_rates,
+        'N' => :indices,
+        'B' => :baskets,
+        'D' => :stock_dividends,
+        'M' => :miscellaneous
+      },
+      'M' => { # Miscellaneous
+        'C' => :combined_instruments,
+        'M' => :miscellaneous
+      }
+    }.freeze
+
+    # @return [String, nil] the category code (position 1)
+    attr_reader :category_code
+
+    # @return [String, nil] the group code (position 2)
+    attr_reader :group_code
+
+    # @return [String, nil] attribute 1 (position 3)
+    attr_reader :attr1
+
+    # @return [String, nil] attribute 2 (position 4)
+    attr_reader :attr2
+
+    # @return [String, nil] attribute 3 (position 5)
+    attr_reader :attr3
+
+    # @return [String, nil] attribute 4 (position 6)
+    attr_reader :attr4
+
+    # @param cfi [String] the CFI string to parse
+    def initialize(cfi)
+      cfi_parts = parse(cfi)
+      @identifier = cfi_parts[:identifier]
+      @category_code = cfi_parts[:category_code]
+      @group_code = cfi_parts[:group_code]
+      @attr1 = cfi_parts[:attr1]
+      @attr2 = cfi_parts[:attr2]
+      @attr3 = cfi_parts[:attr3]
+      @attr4 = cfi_parts[:attr4]
+      @check_digit = nil
+    end
+
+    # @return [Boolean] always false - CFI has no check digit
+    def has_check_digit?
+      false
+    end
+
+    # Validates format including category and group codes.
+    #
+    # @return [Boolean]
+    def valid_format?
+      super && valid_category? && valid_group?
+    end
+
+    # Returns the semantic category name.
+    #
+    # @return [Symbol, nil] category symbol or nil if invalid
+    def category
+      CATEGORIES[category_code]
+    end
+
+    # Returns the semantic group name.
+    #
+    # @return [Symbol, nil] group symbol or nil if invalid
+    def group
+      GROUPS.dig(category_code, group_code)
+    end
+
+    # @return [Boolean] true if category is equity
+    def equity?
+      category_code == 'E'
+    end
+
+    # Voting rights (position 3 = V). Only meaningful for equity.
+    #
+    # @return [Boolean]
+    def voting?
+      equity? && attr1 == 'V'
+    end
+
+    # Non-voting (position 3 = N). Only meaningful for equity.
+    #
+    # @return [Boolean]
+    def non_voting?
+      equity? && attr1 == 'N'
+    end
+
+    # Restricted voting (position 3 = R). Only meaningful for equity.
+    #
+    # @return [Boolean]
+    def restricted_voting?
+      equity? && attr1 == 'R'
+    end
+
+    # Enhanced voting (position 3 = E). Only meaningful for equity.
+    #
+    # @return [Boolean]
+    def enhanced_voting?
+      equity? && attr1 == 'E'
+    end
+
+    # Ownership restrictions exist (position 4 = T). Only meaningful for equity.
+    #
+    # @return [Boolean]
+    def restrictions?
+      equity? && attr2 == 'T'
+    end
+
+    # No ownership restrictions (position 4 = U). Only meaningful for equity.
+    #
+    # @return [Boolean]
+    def no_restrictions?
+      equity? && attr2 == 'U'
+    end
+
+    # Fully paid shares (position 5 = F). Only meaningful for equity.
+    #
+    # @return [Boolean]
+    def fully_paid?
+      equity? && attr3 == 'F'
+    end
+
+    # Nil paid shares (position 5 = O). Only meaningful for equity.
+    #
+    # @return [Boolean]
+    def nil_paid?
+      equity? && attr3 == 'O'
+    end
+
+    # Partly paid shares (position 5 = P). Only meaningful for equity.
+    #
+    # @return [Boolean]
+    def partly_paid?
+      equity? && attr3 == 'P'
+    end
+
+    # Bearer form (position 6 = B). Only meaningful for equity.
+    #
+    # @return [Boolean]
+    def bearer?
+      equity? && attr4 == 'B'
+    end
+
+    # Registered form (position 6 = R). Only meaningful for equity.
+    #
+    # @return [Boolean]
+    def registered?
+      equity? && attr4 == 'R'
+    end
+
+    # @return [String]
+    def to_s
+      identifier.to_s
+    end
+
+    private
+
+    # @return [Boolean]
+    def valid_category?
+      CATEGORIES.key?(category_code)
+    end
+
+    # @return [Boolean]
+    def valid_group?
+      GROUPS.dig(category_code, group_code) != nil
+    end
+  end
+end

--- a/sec_id.gemspec
+++ b/sec_id.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Validate securities identification numbers with ease!'
   spec.description   = 'Validate, calculate check digits, and parse components of securities identifiers. ' \
-                       'Supports ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, and Valoren standards.'
+                       'Supports ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren, and CFI standards.'
   spec.homepage      = 'https://github.com/svyatov/sec_id'
   spec.license       = 'MIT'
 

--- a/spec/sec_id/cfi_spec.rb
+++ b/spec/sec_id/cfi_spec.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+RSpec.describe SecId::CFI do
+  let(:cfi) { described_class.new(cfi_code) }
+
+  # Edge cases - applicable to all identifiers
+  it_behaves_like 'handles edge case inputs'
+
+  describe 'valid CFI parsing' do
+    context 'when CFI is minimal equity (ESXXXX)' do
+      let(:cfi_code) { 'ESXXXX' }
+
+      it 'parses identifier correctly' do
+        expect(cfi.identifier).to eq('ESXXXX')
+      end
+
+      it 'parses category and group codes' do
+        expect(cfi.category_code).to eq('E')
+        expect(cfi.group_code).to eq('S')
+      end
+
+      it 'parses attribute codes' do
+        expect(cfi.attr1).to eq('X')
+        expect(cfi.attr2).to eq('X')
+        expect(cfi.attr3).to eq('X')
+        expect(cfi.attr4).to eq('X')
+      end
+
+      it 'returns semantic category and group' do
+        expect(cfi.category).to eq(:equity)
+        expect(cfi.group).to eq(:common_shares)
+      end
+
+      it 'has no check digit' do
+        expect(cfi.has_check_digit?).to be(false)
+        expect(cfi.check_digit).to be_nil
+      end
+    end
+
+    context 'when CFI has full equity attributes (ESVUFR)' do
+      let(:cfi_code) { 'ESVUFR' }
+
+      it 'parses identifier correctly' do
+        expect(cfi.identifier).to eq('ESVUFR')
+      end
+
+      it 'parses category and group codes' do
+        expect(cfi.category_code).to eq('E')
+        expect(cfi.group_code).to eq('S')
+      end
+
+      it 'parses attribute codes' do
+        expect(cfi.attr1).to eq('V')
+        expect(cfi.attr2).to eq('U')
+        expect(cfi.attr3).to eq('F')
+        expect(cfi.attr4).to eq('R')
+      end
+
+      it 'returns semantic category and group' do
+        expect(cfi.category).to eq(:equity)
+        expect(cfi.group).to eq(:common_shares)
+      end
+    end
+
+    context 'when CFI is debt instrument (DBXXXX)' do
+      let(:cfi_code) { 'DBXXXX' }
+
+      it 'parses category and group codes' do
+        expect(cfi.identifier).to eq('DBXXXX')
+        expect(cfi.category_code).to eq('D')
+        expect(cfi.group_code).to eq('B')
+      end
+
+      it 'returns semantic category and group' do
+        expect(cfi.category).to eq(:debt_instruments)
+        expect(cfi.group).to eq(:bonds)
+      end
+    end
+
+    context 'when CFI is lowercase' do
+      let(:cfi_code) { 'esxxxx' }
+
+      it 'normalizes to uppercase' do
+        expect(cfi.identifier).to eq('ESXXXX')
+        expect(cfi.category_code).to eq('E')
+      end
+    end
+  end
+
+  describe 'category and group accessors' do
+    # Test a representative sample of categories
+    {
+      'ESXXXX' => { category: :equity, group: :common_shares },
+      'EPXXXX' => { category: :equity, group: :preferred_shares },
+      'CIXXXX' => { category: :collective_investment_vehicles, group: :standard_investment_funds },
+      'DBXXXX' => { category: :debt_instruments, group: :bonds },
+      'RAXXXX' => { category: :entitlements, group: :allotment_rights },
+      'OCXXXX' => { category: :listed_options, group: :call_options },
+      'FFXXXX' => { category: :futures, group: :financial_futures },
+      'SRXXXX' => { category: :swaps, group: :rates },
+      'HCXXXX' => { category: :non_listed_options, group: :call_options },
+      'IFXXXX' => { category: :spot, group: :foreign_exchange },
+      'JFXXXX' => { category: :forwards, group: :foreign_exchange },
+      'KRXXXX' => { category: :strategies, group: :rates },
+      'LSXXXX' => { category: :financing, group: :loan_lease },
+      'TIXXXX' => { category: :referential_instruments, group: :currencies },
+      'MCXXXX' => { category: :miscellaneous, group: :combined_instruments }
+    }.each do |code, expected|
+      it "returns #{expected[:category]}/#{expected[:group]} for #{code}" do
+        cfi = described_class.new(code)
+        expect(cfi.category).to eq(expected[:category])
+        expect(cfi.group).to eq(expected[:group])
+      end
+    end
+  end
+
+  describe 'equity predicate methods' do
+    context 'when equity with voting rights (ESVUFR)' do
+      let(:cfi_code) { 'ESVUFR' }
+
+      it { expect(cfi.equity?).to be(true) }
+      it { expect(cfi.voting?).to be(true) }
+      it { expect(cfi.non_voting?).to be(false) }
+      it { expect(cfi.restricted_voting?).to be(false) }
+      it { expect(cfi.enhanced_voting?).to be(false) }
+      it { expect(cfi.no_restrictions?).to be(true) }
+      it { expect(cfi.restrictions?).to be(false) }
+      it { expect(cfi.fully_paid?).to be(true) }
+      it { expect(cfi.nil_paid?).to be(false) }
+      it { expect(cfi.partly_paid?).to be(false) }
+      it { expect(cfi.registered?).to be(true) }
+      it { expect(cfi.bearer?).to be(false) }
+    end
+
+    context 'when equity with non-voting, restrictions, nil-paid, bearer (ESNTOB)' do
+      let(:cfi_code) { 'ESNTOB' }
+
+      it { expect(cfi.equity?).to be(true) }
+      it { expect(cfi.voting?).to be(false) }
+      it { expect(cfi.non_voting?).to be(true) }
+      it { expect(cfi.restrictions?).to be(true) }
+      it { expect(cfi.no_restrictions?).to be(false) }
+      it { expect(cfi.nil_paid?).to be(true) }
+      it { expect(cfi.fully_paid?).to be(false) }
+      it { expect(cfi.bearer?).to be(true) }
+      it { expect(cfi.registered?).to be(false) }
+    end
+
+    context 'when equity with restricted voting (ESRXXX)' do
+      let(:cfi_code) { 'ESRXXX' }
+
+      it { expect(cfi.restricted_voting?).to be(true) }
+    end
+
+    context 'when equity with enhanced voting (ESEXXX)' do
+      let(:cfi_code) { 'ESEXXX' }
+
+      it { expect(cfi.enhanced_voting?).to be(true) }
+    end
+
+    context 'when equity with partly paid (ESXXPX)' do
+      let(:cfi_code) { 'ESXXPX' }
+
+      it { expect(cfi.partly_paid?).to be(true) }
+    end
+
+    context 'when non-equity (DBXXXX)' do
+      let(:cfi_code) { 'DBXXXX' }
+
+      it { expect(cfi.equity?).to be(false) }
+      it { expect(cfi.voting?).to be(false) }
+      it { expect(cfi.non_voting?).to be(false) }
+      it { expect(cfi.restrictions?).to be(false) }
+      it { expect(cfi.fully_paid?).to be(false) }
+      it { expect(cfi.bearer?).to be(false) }
+      it { expect(cfi.registered?).to be(false) }
+    end
+  end
+
+  describe '.valid?' do
+    context 'when CFI is valid' do
+      it 'returns true for various valid CFI codes' do
+        %w[
+          ESXXXX ESVUFR EPXXXX DBXXXX CIXXXX RAXXXX
+          OCXXXX FFXXXX SRXXXX HCXXXX IFXXXX JFXXXX
+          KRXXXX LSXXXX TIXXXX MCXXXX MMXXXX
+        ].each do |code|
+          expect(described_class.valid?(code)).to be(true), "Expected #{code} to be valid"
+        end
+      end
+    end
+
+    context 'when CFI is invalid' do
+      it 'returns false for wrong length' do
+        expect(described_class.valid?('ESXXX')).to be(false)
+        expect(described_class.valid?('ESXXXXX')).to be(false)
+      end
+
+      it 'returns false for digits' do
+        expect(described_class.valid?('ES1234')).to be(false)
+        expect(described_class.valid?('E1XXXX')).to be(false)
+      end
+
+      it 'returns false for invalid category code' do
+        expect(described_class.valid?('QSXXXX')).to be(false)
+        expect(described_class.valid?('ASXXXX')).to be(false)
+        expect(described_class.valid?('ZSXXXX')).to be(false)
+      end
+
+      it 'returns false for invalid group code for category' do
+        expect(described_class.valid?('EZXXXX')).to be(false)
+        expect(described_class.valid?('EAXXXX')).to be(false)
+        expect(described_class.valid?('DQXXXX')).to be(false)
+      end
+
+      it 'returns false for invalid characters' do
+        expect(described_class.valid?('ES-XXX')).to be(false)
+        expect(described_class.valid?('ES XX X')).to be(false)
+      end
+    end
+  end
+
+  describe '.valid_format?' do
+    context 'when format is valid' do
+      it 'returns true for valid formats' do
+        expect(described_class.valid_format?('ESXXXX')).to be(true)
+        expect(described_class.valid_format?('DBXXXX')).to be(true)
+      end
+    end
+
+    context 'when format is invalid' do
+      it 'returns false for wrong length' do
+        expect(described_class.valid_format?('ESXXX')).to be(false)
+      end
+
+      it 'returns false for invalid category' do
+        expect(described_class.valid_format?('QSXXXX')).to be(false)
+      end
+
+      it 'returns false for invalid group' do
+        expect(described_class.valid_format?('EZXXXX')).to be(false)
+      end
+    end
+  end
+
+  describe '#to_s' do
+    let(:cfi_code) { 'ESVUFR' }
+
+    it 'returns the identifier' do
+      expect(cfi.to_s).to eq('ESVUFR')
+    end
+  end
+
+  describe '#full_number' do
+    let(:cfi_code) { 'esvufr' }
+
+    it 'returns the normalized (uppercased) full number' do
+      expect(cfi.full_number).to eq('ESVUFR')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add CFI code validation and semantic parsing per ISO 10962
- Validate format: exactly 6 uppercase letters A-Z
- Validate category code (position 1) against 14 valid values
- Validate group code (position 2) is valid for the given category
- Accept any letter A-Z for attributes (positions 3-6), with X meaning "not applicable"
- Implement equity-specific predicates: `voting?`, `non_voting?`, `restricted_voting?`, `enhanced_voting?`, `restrictions?`, `no_restrictions?`, `fully_paid?`, `nil_paid?`, `partly_paid?`, `bearer?`, `registered?`

Closes #99

## Test plan

- [x] Run linter: `bundle exec rubocop lib/sec_id/cfi.rb spec/sec_id/cfi_spec.rb`
- [x] Run CFI tests: `bundle exec rspec spec/sec_id/cfi_spec.rb` (88 examples)
- [x] Run full test suite: `bundle exec rake` (746 examples, 0 failures)
- [x] Manual verification in console