### PR TITLE
feat: add FISN (Financial Instrument Short Name) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ### Added
 
-- CFI (Classification of Financial Instruments) support with category/group validation and equity-specific predicates
+- FISN (Financial Instrument Short Name) support per ISO 18774 ([#112](https://github.com/svyatov/sec_id/pull/112))
+- CFI (Classification of Financial Instruments) support with category/group validation and equity-specific predicates ([#111](https://github.com/svyatov/sec_id/pull/111))
 - Valoren support (Swiss Security Number) ([@wtn](https://github.com/wtn), [#109](https://github.com/svyatov/sec_id/pull/109))
 - WKN support (Wertpapierkennnummer - German securities identifier) ([@wtn](https://github.com/wtn), [#108](https://github.com/svyatov/sec_id/pull/108))
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - [WKN](#wkn) - Wertpapierkennnummer
   - [Valoren](#valoren) - Swiss Security Number
   - [CFI](#cfi) - Classification of Financial Instruments
+  - [FISN](#fisn) - Financial Instrument Short Name
 - [Development](#development)
 - [Contributing](#contributing)
 - [Changelog](#changelog)
@@ -339,6 +340,29 @@ cfi.registered?    # => true
 ```
 
 CFI validates the category code (position 1) against 14 valid values and the group code (position 2) against valid values for that category. Attribute positions 3-6 accept any letter A-Z, with X meaning "not applicable".
+
+### FISN
+
+> [Financial Instrument Short Name](https://en.wikipedia.org/wiki/ISO_18774) - a human-readable short name for financial instruments per ISO 18774.
+
+```ruby
+# class level
+SecId::FISN.valid?('APPLE INC/SH')        # => true
+SecId::FISN.valid?('apple inc/sh')        # => true (normalized to uppercase)
+SecId::FISN.valid_format?('APPLE INC/SH') # => true
+
+# instance level
+fisn = SecId::FISN.new('APPLE INC/SH')
+fisn.full_number   # => 'APPLE INC/SH'
+fisn.identifier    # => 'APPLE INC/SH'
+fisn.issuer        # => 'APPLE INC'
+fisn.description   # => 'SH'
+fisn.valid?        # => true
+fisn.valid_format? # => true
+fisn.to_s          # => 'APPLE INC/SH'
+```
+
+FISN format: `Issuer Name/Abbreviated Instrument Description` with issuer (1-15 chars) and description (1-19 chars) separated by a forward slash. Character set: uppercase A-Z, digits 0-9, and space.
 
 ## Development
 

--- a/lib/sec_id.rb
+++ b/lib/sec_id.rb
@@ -15,6 +15,7 @@ require 'sec_id/occ'
 require 'sec_id/wkn'
 require 'sec_id/valoren'
 require 'sec_id/cfi'
+require 'sec_id/fisn'
 
 module SecId
   Error = Class.new(StandardError)

--- a/lib/sec_id/fisn.rb
+++ b/lib/sec_id/fisn.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module SecId
+  # Financial Instrument Short Name (FISN) - a human-readable short name for financial
+  # instruments per ISO 18774.
+  #
+  # Format: Issuer Name/Abbreviated Instrument Description
+  # - Total length: 1-35 characters
+  # - Issuer: 1-15 characters (uppercase A-Z, digits 0-9, space)
+  # - Separator: forward slash (/)
+  # - Description: 1-19 characters (uppercase A-Z, digits 0-9, space)
+  #
+  # @see https://en.wikipedia.org/wiki/ISO_18774
+  #
+  # @example Validate a FISN
+  #   SecId::FISN.valid?('APPLE INC/SH')  #=> true
+  #   SecId::FISN.valid?('apple inc/sh')  #=> true (normalized to uppercase)
+  #
+  # @example Access FISN components
+  #   fisn = SecId::FISN.new('APPLE INC/SH')
+  #   fisn.issuer       #=> 'APPLE INC'
+  #   fisn.description  #=> 'SH'
+  class FISN < Base
+    # Regular expression for parsing FISN components.
+    # Issuer: 1-15 chars, Description: 1-19 chars, Total: max 35 chars
+    ID_REGEX = %r{\A
+      (?<identifier>
+        (?<issuer>[A-Z0-9 ]{1,15})
+        /
+        (?<description>[A-Z0-9 ]{1,19}))
+    \z}x
+
+    # @return [String, nil] the issuer name portion (before the slash)
+    attr_reader :issuer
+
+    # @return [String, nil] the abbreviated instrument description (after the slash)
+    attr_reader :description
+
+    # @param fisn [String] the FISN string to parse
+    def initialize(fisn)
+      fisn_parts = parse(fisn)
+      @identifier = fisn_parts[:identifier]
+      @issuer = fisn_parts[:issuer]
+      @description = fisn_parts[:description]
+      @check_digit = nil
+    end
+
+    # @return [Boolean] always false - FISN has no check digit
+    def has_check_digit?
+      false
+    end
+
+    # @return [String]
+    def to_s
+      identifier.to_s
+    end
+  end
+end

--- a/sec_id.gemspec
+++ b/sec_id.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Validate securities identification numbers with ease!'
   spec.description   = 'Validate, calculate check digits, and parse components of securities identifiers. ' \
-                       'Supports ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren, and CFI standards.'
+                       'Supports ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren, CFI, and FISN standards.'
   spec.homepage      = 'https://github.com/svyatov/sec_id'
   spec.license       = 'MIT'
 

--- a/spec/sec_id/fisn_spec.rb
+++ b/spec/sec_id/fisn_spec.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+RSpec.describe SecId::FISN do
+  let(:fisn) { described_class.new(fisn_code) }
+
+  # Edge cases - applicable to all identifiers
+  it_behaves_like 'handles edge case inputs'
+
+  describe 'valid FISN parsing' do
+    context 'when FISN is simple (APPLE INC/SH)' do
+      let(:fisn_code) { 'APPLE INC/SH' }
+
+      it 'parses identifier correctly' do
+        expect(fisn.identifier).to eq('APPLE INC/SH')
+      end
+
+      it 'parses issuer and description' do
+        expect(fisn.issuer).to eq('APPLE INC')
+        expect(fisn.description).to eq('SH')
+      end
+
+      it 'has no check digit' do
+        expect(fisn.has_check_digit?).to be(false)
+        expect(fisn.check_digit).to be_nil
+      end
+    end
+
+    context 'when FISN has numeric characters' do
+      let(:fisn_code) { 'COMPANY 123/BOND 2025' }
+
+      it 'parses identifier correctly' do
+        expect(fisn.identifier).to eq('COMPANY 123/BOND 2025')
+      end
+
+      it 'parses issuer and description' do
+        expect(fisn.issuer).to eq('COMPANY 123')
+        expect(fisn.description).to eq('BOND 2025')
+      end
+    end
+
+    context 'when FISN is lowercase' do
+      let(:fisn_code) { 'apple inc/sh' }
+
+      it 'normalizes to uppercase' do
+        expect(fisn.identifier).to eq('APPLE INC/SH')
+        expect(fisn.issuer).to eq('APPLE INC')
+        expect(fisn.description).to eq('SH')
+      end
+    end
+
+    context 'when FISN has mixed case' do
+      let(:fisn_code) { 'Apple Inc/Shares' }
+
+      it 'normalizes to uppercase' do
+        expect(fisn.identifier).to eq('APPLE INC/SHARES')
+        expect(fisn.issuer).to eq('APPLE INC')
+        expect(fisn.description).to eq('SHARES')
+      end
+    end
+
+    context 'when FISN has minimum lengths (A/B)' do
+      let(:fisn_code) { 'A/B' }
+
+      it 'parses correctly' do
+        expect(fisn.identifier).to eq('A/B')
+        expect(fisn.issuer).to eq('A')
+        expect(fisn.description).to eq('B')
+      end
+
+      it 'is valid' do
+        expect(fisn.valid?).to be(true)
+        expect(fisn.valid_format?).to be(true)
+      end
+    end
+
+    context 'when FISN has maximum lengths' do
+      # 15 char issuer + 1 slash + 19 char description = 35 chars
+      let(:fisn_code) { 'ISSUER NAME 123/DESCRIPTION 1234567' }
+
+      it 'parses correctly' do
+        expect(fisn.issuer).to eq('ISSUER NAME 123')
+        expect(fisn.issuer.length).to eq(15)
+        expect(fisn.description).to eq('DESCRIPTION 1234567')
+        expect(fisn.description.length).to eq(19)
+      end
+    end
+  end
+
+  describe '.valid?' do
+    context 'when FISN is valid' do
+      it 'returns true for various valid FISN codes' do
+        [
+          'APPLE/SH',
+          'A/B',
+          'MICROSOFT/COMMON',
+          'COMPANY 123/BOND',
+          'ABC DEF/XYZ 123',
+        ].each do |code|
+          expect(described_class.valid?(code.gsub('\\', ''))).to be(true), "Expected #{code} to be valid"
+        end
+      end
+
+      it 'returns true for max issuer length (15 chars)' do
+        expect(described_class.valid?('ABCDEFGHIJKLMNO/SH')).to be(true)
+      end
+
+      it 'returns true for max description length (19 chars)' do
+        expect(described_class.valid?('A/ABCDEFGHIJKLMNOPQRS')).to be(true)
+      end
+
+      it 'returns true for max total length (35 chars)' do
+        # 15 char issuer + 1 slash + 19 char description = 35 chars
+        expect(described_class.valid?('ABCDEFGHIJKLMNO/ABCDEFGHIJKLMNOPQRS')).to be(true)
+      end
+    end
+
+    context 'when FISN is invalid' do
+      it 'returns false for missing slash' do
+        expect(described_class.valid?('APPLE INC SH')).to be(false)
+      end
+
+      it 'returns false for empty issuer' do
+        expect(described_class.valid?('/SH')).to be(false)
+      end
+
+      it 'returns false for empty description' do
+        expect(described_class.valid?('APPLE/')).to be(false)
+      end
+
+      it 'returns false for issuer too long (>15 chars)' do
+        expect(described_class.valid?('ABCDEFGHIJKLMNOP/SH')).to be(false)
+      end
+
+      it 'returns false for description too long (>19 chars)' do
+        expect(described_class.valid?('A/ABCDEFGHIJKLMNOPQRST')).to be(false)
+      end
+
+      it 'returns false for invalid characters' do
+        expect(described_class.valid?('APPLE-INC/SH')).to be(false)
+        expect(described_class.valid?('APPLE_INC/SH')).to be(false)
+        expect(described_class.valid?('APPLE.INC/SH')).to be(false)
+        expect(described_class.valid?('APPLE!/SH')).to be(false)
+      end
+
+      it 'returns false for multiple slashes' do
+        expect(described_class.valid?('APPLE/INC/SH')).to be(false)
+      end
+    end
+  end
+
+  describe '.valid_format?' do
+    context 'when format is valid' do
+      it 'returns true for valid formats' do
+        expect(described_class.valid_format?('APPLE INC/SH')).to be(true)
+        expect(described_class.valid_format?('A/B')).to be(true)
+      end
+    end
+
+    context 'when format is invalid' do
+      it 'returns false for missing slash' do
+        expect(described_class.valid_format?('APPLE INC SH')).to be(false)
+      end
+
+      it 'returns false for invalid characters' do
+        expect(described_class.valid_format?('APPLE-INC/SH')).to be(false)
+      end
+    end
+  end
+
+  describe '#to_s' do
+    let(:fisn_code) { 'APPLE INC/SH' }
+
+    it 'returns the identifier' do
+      expect(fisn.to_s).to eq('APPLE INC/SH')
+    end
+  end
+
+  describe '#full_number' do
+    let(:fisn_code) { 'apple inc/sh' }
+
+    it 'returns the normalized (uppercased) full number' do
+      expect(fisn.full_number).to eq('APPLE INC/SH')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add FISN (Financial Instrument Short Name) support per ISO 18774
- FISN provides human-readable short names for financial instruments
- Format: `Issuer Name/Abbreviated Instrument Description` with forward slash separator
- Issuer: 1-15 characters, Description: 1-19 characters
- Character set: uppercase A-Z, digits 0-9, and space
- No check digit (similar to CFI)

## Test plan

- [x] Run `bundle exec rspec spec/sec_id/fisn_spec.rb` - 44 tests pass
- [x] Run `bundle exec rubocop lib/sec_id/fisn.rb spec/sec_id/fisn_spec.rb` - no offenses
- [x] Run `bundle exec rake` - all 790 tests pass, linter clean
- [x] Manual verification in console confirms expected API behavior

Closes #101