### PR TITLE
feat: add CEI (CUSIP Entity Identifier) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ### Added
 
+- CEI (CUSIP Entity Identifier) support for syndicated loan market entity identification ([#113](https://github.com/svyatov/sec_id/pull/113))
 - FISN (Financial Instrument Short Name) support per ISO 18774 ([#112](https://github.com/svyatov/sec_id/pull/112))
 - CFI (Classification of Financial Instruments) support with category/group validation and equity-specific predicates ([#111](https://github.com/svyatov/sec_id/pull/111))
 - Valoren support (Swiss Security Number) ([@wtn](https://github.com/wtn), [#109](https://github.com/svyatov/sec_id/pull/109))

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Supported Standards and Usage](#supported-standards-and-usage)
   - [ISIN](#isin) - International Securities Identification Number
   - [CUSIP](#cusip) - Committee on Uniform Securities Identification Procedures
+  - [CEI](#cei) - CUSIP Entity Identifier
   - [SEDOL](#sedol) - Stock Exchange Daily Official List
   - [FIGI](#figi) - Financial Instrument Global Identifier
   - [LEI](#lei) - Legal Entity Identifier
@@ -107,6 +108,30 @@ cusip.restore!              # => '594918104'
 cusip.calculate_check_digit # => 4
 cusip.to_isin('US')         # => #<SecId::ISIN>
 cusip.cins?                 # => false
+```
+
+### CEI
+
+> [CUSIP Entity Identifier](https://www.cusip.com/identifiers.html) - a 10-character alphanumeric code that identifies legal entities in the syndicated loan market.
+
+```ruby
+# class level
+SecId::CEI.valid?('A0BCDEFGH1')       # => true
+SecId::CEI.valid_format?('A0BCDEFGH') # => true
+SecId::CEI.restore!('A0BCDEFGH')      # => 'A0BCDEFGH1'
+SecId::CEI.check_digit('A0BCDEFGH')   # => 1
+
+# instance level
+cei = SecId::CEI.new('A0BCDEFGH1')
+cei.full_number           # => 'A0BCDEFGH1'
+cei.prefix                # => 'A'
+cei.numeric               # => '0'
+cei.entity_id             # => 'BCDEFGH'
+cei.check_digit           # => 1
+cei.valid?                # => true
+cei.valid_format?         # => true
+cei.restore!              # => 'A0BCDEFGH1'
+cei.calculate_check_digit # => 1
 ```
 
 ### SEDOL

--- a/lib/sec_id.rb
+++ b/lib/sec_id.rb
@@ -14,6 +14,7 @@ require 'sec_id/cik'
 require 'sec_id/occ'
 require 'sec_id/wkn'
 require 'sec_id/valoren'
+require 'sec_id/cei'
 require 'sec_id/cfi'
 require 'sec_id/fisn'
 

--- a/lib/sec_id/cei.rb
+++ b/lib/sec_id/cei.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module SecId
+  # CUSIP Entity Identifier (CEI) - a 10-character alphanumeric code that identifies
+  # legal entities in the syndicated loan market.
+  #
+  # Format: 1 alpha + 1 digit + 7 alphanumeric + 1 check digit
+  #
+  # @see https://www.cusip.com/identifiers.html
+  #
+  # @example Validate a CEI
+  #   SecId::CEI.valid?('A0BCDEFGH1')  #=> true
+  class CEI < Base
+    # Regular expression for parsing CEI components.
+    ID_REGEX = /\A
+      (?<identifier>
+        (?<prefix>[A-Z])
+        (?<numeric>[0-9])
+        (?<entity_id>[A-Z0-9]{7}))
+      (?<check_digit>\d)?
+    \z/x
+
+    # @return [String, nil] the first character (alphabetic)
+    attr_reader :prefix
+
+    # @return [String, nil] the second character (numeric)
+    attr_reader :numeric
+
+    # @return [String, nil] the 7-character entity identifier
+    attr_reader :entity_id
+
+    # @param cei [String] the CEI string to parse
+    def initialize(cei)
+      cei_parts = parse cei
+      @identifier = cei_parts[:identifier]
+      @prefix = cei_parts[:prefix]
+      @numeric = cei_parts[:numeric]
+      @entity_id = cei_parts[:entity_id]
+      @check_digit = cei_parts[:check_digit]&.to_i
+    end
+
+    # @return [Integer] the calculated check digit (0-9)
+    # @raise [InvalidFormatError] if the CEI format is invalid
+    def calculate_check_digit
+      validate_format_for_calculation!
+      mod10(modified_luhn_sum)
+    end
+
+    private
+
+    # Same algorithm as CUSIP (Modulus 10 Double Add Double).
+    #
+    # @return [Integer] the modified Luhn sum
+    # @see https://en.wikipedia.org/wiki/Luhn_algorithm
+    def modified_luhn_sum
+      reversed_id_digits.each_slice(2).reduce(0) do |sum, (even, odd)|
+        double_even = (even || 0) * 2
+        sum + div10mod10(double_even) + div10mod10(odd || 0)
+      end
+    end
+
+    # @return [Array<Integer>] the reversed digit array
+    def reversed_id_digits
+      identifier.each_char.map(&method(:char_to_digit)).reverse!
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add CEI (CUSIP Entity Identifier) validation support for syndicated loan market entity identification
- CEI is a 10-character alphanumeric code: 1 alpha + 1 digit + 7 alphanumeric + 1 check digit
- Uses the same Modified Luhn check digit algorithm as CUSIP

Closes #102

## Test plan

- [x] Run `bundle exec rspec spec/sec_id/cei_spec.rb` - 55 tests pass
- [x] Run `bundle exec rake` - all 845 tests pass, no RuboCop offenses
- [x] Verify README examples work in `bin/console`