### PR TITLE
feat: add ISIN country-aware NSIN extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ### Added
 
+- ISIN `nsin_type` and `to_nsin` methods for country-aware NSIN extraction ([#114](https://github.com/svyatov/sec_id/pull/114))
 - CEI (CUSIP Entity Identifier) support for syndicated loan market entity identification ([#113](https://github.com/svyatov/sec_id/pull/113))
 - FISN (Financial Instrument Short Name) support per ISO 18774 ([#112](https://github.com/svyatov/sec_id/pull/112))
 - CFI (Classification of Financial Instruments) support with category/group validation and equity-specific predicates ([#111](https://github.com/svyatov/sec_id/pull/111))

--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ isin.valid_format?         # => true
 isin.restore!              # => 'US5949181045'
 isin.calculate_check_digit # => 5
 isin.to_cusip              # => #<SecId::CUSIP>
+isin.nsin_type             # => :cusip
+isin.to_nsin               # => #<SecId::CUSIP>
+
+# NSIN extraction for different countries
+SecId::ISIN.new('GB00B02H2F76').nsin_type  # => :sedol
+SecId::ISIN.new('GB00B02H2F76').to_nsin    # => #<SecId::SEDOL>
+SecId::ISIN.new('DE0007164600').nsin_type  # => :wkn
+SecId::ISIN.new('DE0007164600').to_nsin    # => #<SecId::WKN>
+SecId::ISIN.new('CH0012221716').nsin_type  # => :valoren
+SecId::ISIN.new('CH0012221716').to_nsin    # => #<SecId::Valoren>
+SecId::ISIN.new('FR0000120271').nsin_type  # => :generic
+SecId::ISIN.new('FR0000120271').to_nsin    # => '000012027' (raw NSIN string)
 ```
 
 ### CUSIP

--- a/spec/sec_id/isin_spec.rb
+++ b/spec/sec_id/isin_spec.rb
@@ -77,6 +77,132 @@ RSpec.describe SecId::ISIN do
     end
   end
 
+  describe '#nsin_type' do
+    context 'when US ISIN' do
+      let(:isin_number) { 'US0378331005' }
+
+      it 'returns :cusip' do
+        expect(isin.nsin_type).to eq(:cusip)
+      end
+    end
+
+    context 'when CA ISIN' do
+      let(:isin_number) { 'CA9861913023' }
+
+      it 'returns :cusip' do
+        expect(isin.nsin_type).to eq(:cusip)
+      end
+    end
+
+    context 'when GB ISIN' do
+      let(:isin_number) { 'GB00B02H2F76' }
+
+      it 'returns :sedol' do
+        expect(isin.nsin_type).to eq(:sedol)
+      end
+    end
+
+    context 'when IE ISIN' do
+      let(:isin_number) { 'IE00B296YR77' }
+
+      it 'returns :sedol' do
+        expect(isin.nsin_type).to eq(:sedol)
+      end
+    end
+
+    context 'when DE ISIN' do
+      let(:isin_number) { 'DE0007164600' }
+
+      it 'returns :wkn' do
+        expect(isin.nsin_type).to eq(:wkn)
+      end
+    end
+
+    context 'when CH ISIN' do
+      let(:isin_number) { 'CH0012221716' }
+
+      it 'returns :valoren' do
+        expect(isin.nsin_type).to eq(:valoren)
+      end
+    end
+
+    context 'when LI ISIN' do
+      let(:isin_number) { 'LI0000000000' }
+
+      it 'returns :valoren' do
+        expect(isin.nsin_type).to eq(:valoren)
+      end
+    end
+
+    context 'when FR ISIN' do
+      let(:isin_number) { 'FR0000120271' }
+
+      it 'returns :generic' do
+        expect(isin.nsin_type).to eq(:generic)
+      end
+    end
+  end
+
+  describe '#to_nsin' do
+    context 'when US ISIN' do
+      let(:isin_number) { 'US0378331005' }
+
+      it 'returns CUSIP instance with correct value' do
+        result = isin.to_nsin
+        expect(result).to be_a(SecId::CUSIP)
+        expect(result.full_number).to eq('037833100')
+      end
+    end
+
+    context 'when GB ISIN' do
+      let(:isin_number) { 'GB00B02H2F76' }
+
+      it 'returns SEDOL instance with correct value' do
+        result = isin.to_nsin
+        expect(result).to be_a(SecId::SEDOL)
+        expect(result.full_number).to eq('B02H2F7')
+      end
+    end
+
+    context 'when DE ISIN' do
+      let(:isin_number) { 'DE0007164600' }
+
+      it 'returns WKN instance with correct value' do
+        result = isin.to_nsin
+        expect(result).to be_a(SecId::WKN)
+        expect(result.full_number).to eq('716460')
+      end
+    end
+
+    context 'when CH ISIN' do
+      let(:isin_number) { 'CH0012221716' }
+
+      it 'returns Valoren instance with correct value' do
+        result = isin.to_nsin
+        expect(result).to be_a(SecId::Valoren)
+        expect(result.identifier).to eq('1222171')
+      end
+    end
+
+    context 'when FR ISIN' do
+      let(:isin_number) { 'FR0000120271' }
+
+      it 'returns raw NSIN string' do
+        result = isin.to_nsin
+        expect(result).to be_a(String)
+        expect(result).to eq('000012027')
+      end
+    end
+
+    context 'when invalid format' do
+      let(:isin_number) { '00B296YR77' }
+
+      it 'raises InvalidFormatError' do
+        expect { isin.to_nsin }.to raise_error(SecId::InvalidFormatError, 'Invalid ISIN format')
+      end
+    end
+  end
+
   describe '.valid?' do
     context 'when ISIN is valid' do
       it 'returns true' do


### PR DESCRIPTION
## Summary

- Add `nsin_type` method returning the type of NSIN embedded in an ISIN (`:cusip`, `:sedol`, `:wkn`, `:valoren`, or `:generic`)
- Add `to_nsin` method that extracts the appropriate identifier object or raw NSIN string
- Add `NSIN_COUNTRY_TYPES` constant mapping country codes to identifier types

## NSIN Extraction Logic

| Country | Type | Extraction |
|---------|------|------------|
| US, CA, etc. (CGS) | `:cusip` | Full NSIN via `to_cusip` |
| GB, IE | `:sedol` | Last 7 chars (`nsin[2..]`) |
| DE | `:wkn` | Last 6 chars (`nsin[3..]`) |
| CH, LI | `:valoren` | Full NSIN (Valoren handles padding) |
| Others | `:generic` | Raw NSIN string |

Closes #103

## Test plan

- [x] Run linter: `bundle exec rubocop lib/sec_id/isin.rb spec/sec_id/isin_spec.rb`
- [x] Run ISIN tests: `bundle exec rspec spec/sec_id/isin_spec.rb`
- [x] Run full test suite: `bundle exec rake` (859 examples, 0 failures)