### PR TITLE
feat: add identifier generation (.generate) for all types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `.generate` on all 13 identifier types plus a central `SecID.generate(:type)` dispatcher for producing syntactically valid identifiers (with correct check digits where applicable) as test fixtures — accepts an optional `random:` keyword (a Ruby `Random`) for reproducible output. Generated values are valid in format only and are not real, registered securities
+
 ### Changed
 
 - `SecID.valid?` and `SecID.parse` are faster and allocate less — `SecID.valid?` short-circuits on the first matching type instead of running a full detect-and-sort, and `SecID.parse` reuses the instance built during detection instead of instantiating the matched type a second time

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Architecture
 
-This is a Ruby toolkit for securities identifiers (ISIN, CUSIP, CEI, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren, CFI, FISN) — validate, normalize, parse, detect, convert, and calculate check digits.
+This is a Ruby toolkit for securities identifiers (ISIN, CUSIP, CEI, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren, CFI, FISN) — validate, normalize, parse, detect, convert, generate, and calculate check digits.
 
 ### Directory Layout
 
@@ -31,9 +31,10 @@ This is a Ruby toolkit for securities identifiers (ISIN, CUSIP, CEI, SEDOL, FIGI
 
 ### Class Hierarchy
 
-All identifier classes inherit from `SecID::Base` (`lib/sec_id/base.rb`), a thin coordinator that includes two concerns:
+All identifier classes inherit from `SecID::Base` (`lib/sec_id/base.rb`), a thin coordinator that includes three concerns:
 - `Normalizable` — normalization: `#normalized` / `#normalize`, `#normalize!`, `.normalize(id)`, `#to_s`, `#to_str`, `SEPARATORS`
 - `Validatable` — validation: `#valid?`, `#validate`, `#errors`, `#validate!`, `.valid?`, `.validate`, `.validate!`, `.error_class_for`, `ERROR_MAP`
+- `Generatable` — generation: `.generate(random:)`, `random_string(charset, length, random:)` helper, `ALPHA`/`DIGITS`/`ALPHANUMERIC` charset constants
 
 Base itself keeps:
 - Class-level metadata methods: `short_name`, `full_name`, `id_length`, `example`, `has_check_digit?`
@@ -70,6 +71,7 @@ Identifier classes auto-register via `Base.inherited`. Access them through:
 - `SecID.extract(text, types: nil)` — finds identifiers in freeform text, returns `Array<Match>`
 - `SecID.scan(text, types: nil)` — lazy version of `extract`, returns `Enumerator<Match>`
 - `SecID.explain(str, types: nil)` — returns per-type validation results for debugging detection
+- `SecID.generate(key, random: Random.new)` — returns a generated, format-valid instance for a type symbol (raises `ArgumentError` on unknown type); generated values are valid in format only, not real securities
 
 ### Detector (`lib/sec_id/detector.rb`)
 
@@ -130,6 +132,23 @@ Validation overrides (private):
 Helper methods (private):
 - `mod10`, `div10mod10`, `mod97` - Check digit calculation helpers
 - `validate_format_for_calculation!` - Raises error if format invalid
+
+#### Generatable (`generatable.rb`)
+
+Provides generation of new, format-valid identifiers for use as test fixtures. Included in `Base`, so every type inherits a `.generate` entry point. **Generated values are valid in format only — they are not real, registered securities** (random country codes, FIGI prefixes, OCC dates, CFI attributes).
+
+Constants (charset building blocks): `ALPHA`, `DIGITS`, `ALPHANUMERIC`.
+
+Class methods (added via `included`/`extend(ClassMethods)`):
+- `generate(random: Random.new)` - Builds `new(generate_body(random))`, then calls `restore!` when `has_check_digit?` is true, else returns the instance
+- `random_string(charset, length, random:)` (private) - Draws `length` characters from `charset` using `Array#sample(random:)`
+
+Per-type hooks:
+- Each type defines a private class-level `generate_body(random)` returning a valid body (identifier without check digit); check-digit types' bodies are restored by the default `generate`
+- Check-digit-less types (CFI, FISN) compose the complete identifier in `generate_body`; no `restore!` is called
+- IBAN composes a full-length body with placeholder `"00"` check digits in `generate_body`; the default `generate` then calls `restore!` to replace them with the real two-digit check value
+- OCC overrides `generate` entirely (via `OCC.build`)
+- FIGI resamples its prefix until it is not in `RESTRICTED_PREFIXES`; IBAN generates only numeric-BBAN countries (`NUMERIC_COUNTRY_RULES`); CIK/Valoren use a random integer (not a digit char-fill) to avoid leading-zero bodies
 
 ### Identifier Classes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SecID [![Gem Version](https://img.shields.io/gem/v/sec_id)](https://rubygems.org/gems/sec_id) [![Codecov](https://img.shields.io/codecov/c/github/svyatov/sec_id)](https://app.codecov.io/gh/svyatov/sec_id) [![CI](https://github.com/svyatov/sec_id/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/svyatov/sec_id/actions?query=workflow%3ACI)
 
-> A Ruby toolkit for securities identifiers — validate, parse, normalize, detect, and convert.
+> A Ruby toolkit for securities identifiers — validate, parse, normalize, detect, convert, and generate.
 
 ## Table of Contents
 
@@ -11,6 +11,7 @@
   - [Text Scanning](#text-scanning) - find identifiers in freeform text
   - [Debugging Detection](#debugging-detection) - understand why strings match or don't
   - [Structured Validation](#structured-validation) - detailed error codes and messages
+  - [Generating Test Fixtures](#generating-test-fixtures) - produce valid identifiers for tests
   - [ISIN](#isin) - International Securities Identification Number
   - [CUSIP](#cusip) - Committee on Uniform Securities Identification Procedures
   - [CEI](#cei) - CUSIP Entity Identifier
@@ -252,6 +253,26 @@ SecID::FIGI.new('BSG000BLNNH6').validate!
 # Class-level convenience method (returns the instance)
 isin = SecID::ISIN.validate!('US5949181045')  # => #<SecID::ISIN>
 ```
+
+### Generating Test Fixtures
+
+Generate syntactically valid identifiers — with correct check digits where applicable — for use as test fixtures. Available per class and via the central dispatcher:
+
+```ruby
+SecID::ISIN.generate          # => #<SecID::ISIN ...>
+SecID::ISIN.generate.valid?   # => true
+
+# Central dispatcher by type symbol (mirrors SecID[])
+SecID.generate(:cusip)        # => #<SecID::CUSIP ...>
+SecID.generate(:nope)         # => raises ArgumentError: Unknown identifier type: :nope
+
+# Pass a seeded Random for reproducible output
+SecID::LEI.generate(random: Random.new(42)) == SecID::LEI.generate(random: Random.new(42))  # => true
+```
+
+> **Generated identifiers are valid in format only — they are not real, registered securities.**
+> Country codes, FIGI prefixes, OCC expiry dates, and CFI attributes are random and do not map to
+> real-world instruments. Use them as test fixtures, not as references to actual securities.
 
 ### ISIN
 

--- a/lib/sec_id.rb
+++ b/lib/sec_id.rb
@@ -120,6 +120,20 @@ module SecID
       result || raise(InvalidFormatError, parse_error_message(str, types))
     end
 
+    # Generates a new, format-valid identifier instance of the given type.
+    #
+    # @note Generated identifiers are valid in format only — they are not real,
+    #   registered securities.
+    #
+    # @param key [Symbol] identifier type (e.g. :isin, :cusip)
+    # @param random [Random] seedable source for reproducible output
+    # @return [SecID::Base] a generated, format-valid instance of the type mapped to `key`
+    #   (e.g. {SecID::ISIN} for `:isin`)
+    # @raise [ArgumentError] if key is unknown
+    def generate(key, random: Random.new)
+      self[key].generate(random: random)
+    end
+
     private
 
     # @return [void]
@@ -181,6 +195,7 @@ require 'sec_id/errors'
 require 'sec_id/concerns/normalizable'
 require 'sec_id/concerns/validatable'
 require 'sec_id/concerns/checkable'
+require 'sec_id/concerns/generatable'
 require 'sec_id/base'
 require 'sec_id/detector'
 require 'sec_id/scanner'

--- a/lib/sec_id/base.rb
+++ b/lib/sec_id/base.rb
@@ -41,6 +41,7 @@ module SecID
   class Base
     include Normalizable
     include Validatable
+    include Generatable
 
     # @return [String] the original input after normalization (stripped and uppercased)
     attr_reader :full_id

--- a/lib/sec_id/cei.rb
+++ b/lib/sec_id/cei.rb
@@ -53,6 +53,16 @@ module SecID
       mod10(luhn_sum_double_add_double(reversed_digits_single(identifier)))
     end
 
+    # Generates a random CEI body: 1 letter + 1 digit + 7 alphanumeric characters.
+    #
+    # @param random [Random] source of randomness
+    # @return [String] a 9-character CEI body without check digit
+    def self.generate_body(random)
+      "#{random_string(ALPHA, 1, random: random)}#{random_string(DIGITS, 1, random: random)}" \
+        "#{random_string(ALPHANUMERIC, 7, random: random)}"
+    end
+    private_class_method :generate_body
+
     private
 
     # @return [Hash]

--- a/lib/sec_id/cfi.rb
+++ b/lib/sec_id/cfi.rb
@@ -312,6 +312,17 @@ module SecID
       identifier.to_s
     end
 
+    # Generates a random CFI: a category, a valid group for it, and 4 attribute letters.
+    #
+    # @param random [Random] source of randomness
+    # @return [String] a 6-character CFI code
+    def self.generate_body(random)
+      category = CATEGORIES.keys.sample(random: random)
+      group = GROUPS[category].keys.sample(random: random)
+      "#{category}#{group}#{random_string(ALPHA, 4, random: random)}"
+    end
+    private_class_method :generate_body
+
     private
 
     # @return [Hash]

--- a/lib/sec_id/cik.rb
+++ b/lib/sec_id/cik.rb
@@ -54,5 +54,14 @@ module SecID
     def to_s
       full_id
     end
+
+    # Generates a random CIK: an integer rendered without leading zeros.
+    #
+    # @param random [Random] source of randomness
+    # @return [String] a 1-10 digit CIK
+    def self.generate_body(random)
+      random.rand(1..9_999_999_999).to_s
+    end
+    private_class_method :generate_body
   end
 end

--- a/lib/sec_id/concerns/generatable.rb
+++ b/lib/sec_id/concerns/generatable.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module SecID
+  # Provides generation of new, format-valid identifiers for use as test fixtures.
+  #
+  # Including classes define a class-level `generate_body(random)` returning a valid
+  # body (the identifier without its check digit). The default {ClassMethods#generate}
+  # builds an instance from that body and restores the check digit for check-digit types.
+  # Types whose shape is not "body (+ check digit)" compose the full identifier in
+  # `generate_body` (CFI, FISN) or override `generate` entirely (OCC).
+  #
+  # @note Generated identifiers are valid in format only — they are not real,
+  #   registered securities. Country codes, prefixes, dates, and attributes are random.
+  #
+  # @example Generate a fixture
+  #   SecID::ISIN.generate           #=> #<SecID::ISIN ...> (valid?)
+  #   SecID::ISIN.generate.valid?    #=> true
+  #
+  # @example Reproducible output via a seeded Random
+  #   SecID::ISIN.generate(random: Random.new(42)) == SecID::ISIN.generate(random: Random.new(42))
+  module Generatable
+    # Uppercase letters A-Z.
+    ALPHA = ('A'..'Z').to_a.freeze
+
+    # Decimal digits 0-9.
+    DIGITS = ('0'..'9').to_a.freeze
+
+    # Alphanumeric characters (digits then uppercase letters).
+    ALPHANUMERIC = (DIGITS + ALPHA).freeze
+
+    # @api private
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    # Class methods added when Generatable is included.
+    module ClassMethods
+      # Generates a new, format-valid identifier instance.
+      #
+      # @note Generated identifiers are valid in format only — they are not real,
+      #   registered securities.
+      #
+      # @param random [Random] seedable source for reproducible output
+      # @return [self] a generated instance of the identifier type (e.g. {SecID::ISIN}) for which `valid?` is true
+      def generate(random: Random.new)
+        instance = new(generate_body(random))
+        has_check_digit? ? instance.restore! : instance
+      end
+
+      private
+
+      # Subclasses must implement this to return a valid body (identifier without check digit),
+      # unless they override {#generate} entirely (as OCC does).
+      #
+      # @param _random [Random] source of randomness
+      # @return [String] the generated body
+      # @raise [NotImplementedError] if the identifier type does not implement it
+      def generate_body(_random)
+        raise NotImplementedError, "#{self} must implement .generate_body"
+      end
+
+      # @param charset [Array<String>] characters to draw from
+      # @param length [Integer] number of characters to generate
+      # @param random [Random] source of randomness
+      # @return [String] a random string of the given length
+      def random_string(charset, length, random:)
+        Array.new(length) { charset.sample(random: random) }.join
+      end
+    end
+  end
+end

--- a/lib/sec_id/cusip.rb
+++ b/lib/sec_id/cusip.rb
@@ -59,6 +59,15 @@ module SecID
       mod10(luhn_sum_double_add_double(reversed_digits_single(identifier)))
     end
 
+    # Generates a random CUSIP body: 8 alphanumeric characters.
+    #
+    # @param random [Random] source of randomness
+    # @return [String] an 8-character CUSIP body without check digit
+    def self.generate_body(random)
+      random_string(ALPHANUMERIC, 8, random: random)
+    end
+    private_class_method :generate_body
+
     # @param country_code [String] the ISO 3166-1 alpha-2 country code (must be CGS country)
     # @return [ISIN] a new ISIN instance
     # @raise [InvalidFormatError] if the country code is not a CGS country

--- a/lib/sec_id/figi.rb
+++ b/lib/sec_id/figi.rb
@@ -35,6 +35,9 @@ module SecID
     # Country-code prefixes that are restricted from use in FIGI.
     RESTRICTED_PREFIXES = Set.new %w[BS BM GG GB GH KY VG]
 
+    # Characters valid in a FIGI (alphanumeric excluding vowels).
+    GENERATE_CHARSET = ALPHANUMERIC.grep(VALID_CHARS_REGEX).freeze
+
     # @return [String, nil] the 2-character prefix
     attr_reader :prefix
 
@@ -63,6 +66,17 @@ module SecID
       validate_format_for_calculation!
       mod10(luhn_sum_indexed(reversed_digits_single(identifier)))
     end
+
+    # Generates a random FIGI body: non-reserved 2-char prefix + 'G' + 8-char random part.
+    #
+    # @param random [Random] source of randomness
+    # @return [String] an 11-character FIGI body without check digit
+    def self.generate_body(random)
+      prefix = random_string(GENERATE_CHARSET, 2, random: random)
+      prefix = random_string(GENERATE_CHARSET, 2, random: random) while RESTRICTED_PREFIXES.include?(prefix)
+      "#{prefix}G#{random_string(GENERATE_CHARSET, 8, random: random)}"
+    end
+    private_class_method :generate_body
 
     private
 

--- a/lib/sec_id/fisn.rb
+++ b/lib/sec_id/fisn.rb
@@ -36,6 +36,9 @@ module SecID
         (?<description>[A-Z0-9 ]{1,19}))
     \z}x
 
+    # Characters valid in a FISN segment (alphanumeric and space).
+    FISN_CHARSET = (ALPHANUMERIC + [' ']).freeze
+
     # @return [String, nil] the issuer name portion (before the slash)
     attr_reader :issuer
 
@@ -54,6 +57,29 @@ module SecID
     def to_s
       identifier.to_s
     end
+
+    # Generates a random FISN: issuer (1-15 chars) + '/' + description (1-19 chars).
+    #
+    # @param random [Random] source of randomness
+    # @return [String] a generated FISN, at most 35 characters
+    def self.generate_body(random)
+      "#{generate_part(random.rand(1..15), random)}/#{generate_part(random.rand(1..19), random)}"
+    end
+    private_class_method :generate_body
+
+    # Generates a FISN segment whose first and last characters are not spaces,
+    # so Base#parse's strip leaves both segments intact.
+    #
+    # @param length [Integer] the segment length
+    # @param random [Random] source of randomness
+    # @return [String] a segment of the given length
+    def self.generate_part(length, random)
+      chars = Array.new(length) { FISN_CHARSET.sample(random: random) }
+      chars[0] = ALPHANUMERIC.sample(random: random)
+      chars[-1] = ALPHANUMERIC.sample(random: random)
+      chars.join
+    end
+    private_class_method :generate_part
 
     private
 

--- a/lib/sec_id/iban.rb
+++ b/lib/sec_id/iban.rb
@@ -33,6 +33,10 @@ module SecID
       (?<rest>[A-Z0-9]{13,32})
     \z/x
 
+    # Country rules whose BBAN format accepts an all-digit value, used for generation.
+    # Restricts generation to numeric BBANs so output validates without interpreting the format regex.
+    NUMERIC_COUNTRY_RULES = COUNTRY_RULES.select { |_cc, rule| rule[:format].match?('0' * rule[:length]) }.to_a.freeze
+
     # Returns sorted array of all supported country codes.
     #
     # @return [Array<String>]
@@ -85,6 +89,17 @@ module SecID
       validate_format_for_calculation!
       mod97(numeric_string_for_check)
     end
+
+    # Generates a random IBAN body for a numeric-BBAN country with placeholder check digits.
+    # The default {Generatable::ClassMethods#generate} restores the real check digits via `restore!`.
+    #
+    # @param random [Random] source of randomness
+    # @return [String] a country code + "00" + numeric BBAN
+    def self.generate_body(random)
+      country_code, rule = NUMERIC_COUNTRY_RULES.sample(random: random)
+      "#{country_code}00#{random_string(DIGITS, rule[:length], random: random)}"
+    end
+    private_class_method :generate_body
 
     # @return [Boolean]
     def valid_bban_format?

--- a/lib/sec_id/isin.rb
+++ b/lib/sec_id/isin.rb
@@ -84,6 +84,15 @@ module SecID
       mod10(luhn_sum_standard(reversed_digits_multi(identifier)))
     end
 
+    # Generates a random ISIN body: 2-letter country code + 9-character NSIN.
+    #
+    # @param random [Random] source of randomness
+    # @return [String] an 11-character ISIN body without check digit
+    def self.generate_body(random)
+      "#{random_string(ALPHA, 2, random: random)}#{random_string(ALPHANUMERIC, 9, random: random)}"
+    end
+    private_class_method :generate_body
+
     # @return [CUSIP] a new CUSIP instance
     # @raise [InvalidFormatError] if the country code is not a CGS country
     def to_cusip

--- a/lib/sec_id/lei.rb
+++ b/lib/sec_id/lei.rb
@@ -64,6 +64,15 @@ module SecID
       mod97("#{numeric_identifier}00")
     end
 
+    # Generates a random LEI body: 18 alphanumeric characters.
+    #
+    # @param random [Random] source of randomness
+    # @return [String] an 18-character LEI body without check digits
+    def self.generate_body(random)
+      random_string(ALPHANUMERIC, 18, random: random)
+    end
+    private_class_method :generate_body
+
     private
 
     # @return [Hash]

--- a/lib/sec_id/occ.rb
+++ b/lib/sec_id/occ.rb
@@ -46,6 +46,22 @@ module SecID
     # @return [String, nil] the strike price in mills (thousandths of a dollar, represented as an 8-digit string)
     attr_reader :strike_mills
 
+    # Generates a random OCC option symbol.
+    #
+    # @note Generated symbols are valid in format only — they are not real, listed options.
+    #
+    # @param random [Random] source of randomness
+    # @return [OCC] a generated, valid OCC instance
+    def self.generate(random: Random.new)
+      build(
+        underlying: random_string(ALPHA, random.rand(1..5), random: random),
+        # Year 2000-2068 so the 2-digit-year symbol round-trips: strptime maps %y 69-99 to 19xx.
+        date: Date.new(2000 + random.rand(0..68), random.rand(1..12), random.rand(1..28)),
+        type: %w[C P].sample(random: random),
+        strike: random_string(DIGITS, 8, random: random)
+      )
+    end
+
     class << self
       # Builds an OCC symbol from components.
       #

--- a/lib/sec_id/sedol.rb
+++ b/lib/sec_id/sedol.rb
@@ -32,6 +32,9 @@ module SecID
     # Weights applied to each character position in the check digit calculation.
     CHARACTER_WEIGHTS = [1, 3, 1, 7, 3, 9].freeze
 
+    # Characters valid in a SEDOL body (alphanumeric excluding vowels).
+    GENERATE_CHARSET = ALPHANUMERIC.grep(VALID_CHARS_REGEX).freeze
+
     # @param sedol [String] the SEDOL string to parse
     def initialize(sedol)
       sedol_parts = parse sedol
@@ -59,6 +62,15 @@ module SecID
       validate_format_for_calculation!
       mod10(weighted_sum)
     end
+
+    # Generates a random SEDOL body: 6 characters excluding vowels.
+    #
+    # @param random [Random] source of randomness
+    # @return [String] a 6-character SEDOL body without check digit
+    def self.generate_body(random)
+      random_string(GENERATE_CHARSET, 6, random: random)
+    end
+    private_class_method :generate_body
 
     private
 

--- a/lib/sec_id/valoren.rb
+++ b/lib/sec_id/valoren.rb
@@ -77,5 +77,14 @@ module SecID
     def to_s
       full_id
     end
+
+    # Generates a random Valoren: an integer rendered without leading zeros.
+    #
+    # @param random [Random] source of randomness
+    # @return [String] a 5-9 digit Valoren
+    def self.generate_body(random)
+      random.rand(10_000..999_999_999).to_s
+    end
+    private_class_method :generate_body
   end
 end

--- a/lib/sec_id/wkn.rb
+++ b/lib/sec_id/wkn.rb
@@ -24,6 +24,9 @@ module SecID
       (?<identifier>[0-9A-HJ-NP-Z]{6})
     \z/x
 
+    # Characters valid in a WKN (alphanumeric excluding I and O).
+    GENERATE_CHARSET = ALPHANUMERIC.grep(VALID_CHARS_REGEX).freeze
+
     # @param wkn [String] the WKN string to parse
     def initialize(wkn)
       wkn_parts = parse(wkn)
@@ -40,5 +43,14 @@ module SecID
 
       ISIN.new("#{country_code}000#{identifier}").restore!
     end
+
+    # Generates a random WKN: 6 characters excluding I and O.
+    #
+    # @param random [Random] source of randomness
+    # @return [String] a 6-character WKN
+    def self.generate_body(random)
+      random_string(GENERATE_CHARSET, 6, random: random)
+    end
+    private_class_method :generate_body
   end
 end

--- a/sec_id.gemspec
+++ b/sec_id.gemspec
@@ -10,10 +10,12 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Leonid Svyatov']
   spec.email         = ['leonid@svyatov.ru']
 
-  spec.summary       = 'A Ruby toolkit for securities identifiers — validate, parse, normalize, detect, and convert.'
-  spec.description   = 'Validate, normalize, parse, and convert securities identifiers. Auto-detect identifier ' \
-                       'type from any string. Calculate and restore check digits. Supports ISIN, CUSIP, CEI, ' \
-                       'SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren, CFI, and FISN.'
+  spec.summary       = 'A Ruby toolkit for securities identifiers — validate, parse, normalize, detect, convert, ' \
+                       'and generate.'
+  spec.description   = 'Validate, normalize, parse, convert, and generate securities identifiers. Auto-detect ' \
+                       'identifier type from any string. Calculate and restore check digits. Generate format-valid ' \
+                       'identifiers as test fixtures. Supports ISIN, CUSIP, CEI, SEDOL, FIGI, LEI, IBAN, CIK, OCC, ' \
+                       'WKN, Valoren, CFI, and FISN.'
   spec.homepage      = 'https://github.com/svyatov/sec_id'
   spec.license       = 'MIT'
 

--- a/spec/sec_id/cei_spec.rb
+++ b/spec/sec_id/cei_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe SecID::CEI do
                   id_length: 10,
                   has_check_digit: true
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: 'A0BCDEFGH1',
                   dirty_id: 'a0-bcde-fgh1',

--- a/spec/sec_id/cfi_spec.rb
+++ b/spec/sec_id/cfi_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe SecID::CFI do
                   id_length: 6,
                   has_check_digit: false
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: 'ESVUFR',
                   dirty_id: 'esvufr',
@@ -363,6 +365,12 @@ RSpec.describe SecID::CFI do
       it { expect(cfi.partly_paid?).to be(false) }
       it { expect(cfi.bearer?).to be(false) }
       it { expect(cfi.registered?).to be(false) }
+    end
+  end
+
+  describe '.generate' do
+    it 'generates a group valid for its category' do
+      expect(described_class.generate.group).not_to be_nil
     end
   end
 end

--- a/spec/sec_id/cik_spec.rb
+++ b/spec/sec_id/cik_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe SecID::CIK do
                   dirty_id: '  1521365  ',
                   invalid_id: '0000000000'
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: '0001521365',
                   canonical_id: '0001521365',
@@ -138,6 +140,14 @@ RSpec.describe SecID::CIK do
         expect(described_class.normalize('001072424')).to eq('0001072424')
         expect(described_class.normalize('0001072424')).to eq('0001072424')
       end
+    end
+  end
+
+  describe '.generate' do
+    it 'generates a value within the valid length range that pads when normalized' do
+      cik = described_class.generate
+      expect(described_class::ID_LENGTH).to cover(cik.full_id.length)
+      expect(cik.normalized.length).to eq(10)
     end
   end
 end

--- a/spec/sec_id/cusip_spec.rb
+++ b/spec/sec_id/cusip_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe SecID::CUSIP do
                   id_length: 9,
                   has_check_digit: true
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: '037833100',
                   dirty_id: '037-833-100',

--- a/spec/sec_id/figi_spec.rb
+++ b/spec/sec_id/figi_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe SecID::FIGI do
                   id_length: 12,
                   has_check_digit: true
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: 'BBG000BLNNH6',
                   dirty_id: 'bbg-000-blnnh6',
@@ -175,6 +177,29 @@ RSpec.describe SecID::FIGI do
   describe '#to_pretty_s' do
     it 'formats as prefix+G + random_part + check_digit' do
       expect(described_class.new('BBG000BLNQ16').to_pretty_s).to eq('BBG 000BLNQ1 6')
+    end
+  end
+
+  describe '.generate' do
+    it 'uses a non-reserved prefix and a vowel-free random part' do
+      figi = described_class.generate
+      expect(described_class::RESTRICTED_PREFIXES).not_to include(figi.prefix)
+      expect(figi.random_part).to match(/\A[B-DF-HJ-NP-TV-Z0-9]{8}\z/)
+    end
+
+    it 'resamples when the first draw is a restricted prefix' do
+      # Seed 3's first two-character draw is the restricted prefix 'BS', forcing the
+      # rejection-sampling loop to retry until it lands on a permitted prefix.
+      figi = described_class.generate(random: Random.new(3))
+      expect(figi.prefix).not_to eq('BS')
+      expect(described_class::RESTRICTED_PREFIXES).not_to include(figi.prefix)
+    end
+
+    it 'never returns a restricted prefix across many seeds' do
+      (0..300).each do |seed|
+        prefix = described_class.generate(random: Random.new(seed)).prefix
+        expect(described_class::RESTRICTED_PREFIXES).not_to include(prefix)
+      end
     end
   end
 end

--- a/spec/sec_id/fisn_spec.rb
+++ b/spec/sec_id/fisn_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe SecID::FISN do
                   id_length: 3..35,
                   has_check_digit: false
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: 'APPLE INC/SH',
                   dirty_id: 'apple inc/sh',
@@ -276,6 +278,14 @@ RSpec.describe SecID::FISN do
 
     it 'returns the normalized (uppercased) full id' do
       expect(fisn.full_id).to eq('APPLE INC/SH')
+    end
+  end
+
+  describe '.generate' do
+    it 'generates issuer and description within their length limits' do
+      fisn = described_class.generate
+      expect(fisn.issuer.length).to be_between(1, 15)
+      expect(fisn.description.length).to be_between(1, 19)
     end
   end
 end

--- a/spec/sec_id/iban_spec.rb
+++ b/spec/sec_id/iban_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe SecID::IBAN do
                   id_length: 15..34,
                   has_check_digit: true
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: 'GB29NWBK60161331926819',
                   dirty_id: 'GB29 NWBK 6016 1331 9268 19',
@@ -580,6 +582,20 @@ RSpec.describe SecID::IBAN do
 
     it 'formats shorter IBANs' do
       expect(described_class.new('GB29NWBK60161331926819').to_pretty_s).to eq('GB29 NWBK 6016 1331 9268 19')
+    end
+  end
+
+  describe '.generate' do
+    it 'generates a supported country code' do
+      expect(described_class.supported_countries).to include(described_class.generate.country_code)
+    end
+
+    it 'generates an all-numeric BBAN' do
+      expect(described_class.generate.bban).to match(/\A\d+\z/)
+    end
+
+    it 'has at least one numeric-BBAN country rule to draw from' do
+      expect(described_class::NUMERIC_COUNTRY_RULES).not_to be_empty
     end
   end
 end

--- a/spec/sec_id/isin_spec.rb
+++ b/spec/sec_id/isin_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe SecID::ISIN do
                   id_length: 12,
                   has_check_digit: true
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: 'US5949181045',
                   dirty_id: 'us-5949-1810-45',

--- a/spec/sec_id/lei_spec.rb
+++ b/spec/sec_id/lei_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe SecID::LEI do
                   id_length: 20,
                   has_check_digit: true
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: '529900T8BM49AURSDO55',
                   dirty_id: '5299 00t8 bm49 aurs do55',

--- a/spec/sec_id/occ_spec.rb
+++ b/spec/sec_id/occ_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe SecID::OCC do
                   dirty_id: 'eqx   260116c00005500',
                   invalid_id: 'ZVZZT'
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: 'EQX   260116C00005500',
                   canonical_id: 'EQX   260116C00005500',
@@ -343,6 +345,24 @@ RSpec.describe SecID::OCC do
 
     it 'formats shorter underlying symbols' do
       expect(described_class.new('EQX   260116C00005500').to_pretty_s).to eq('EQX 260116 C 00005500')
+    end
+  end
+
+  describe '.generate' do
+    it 'generates a parseable expiry date' do
+      expect(described_class.generate.date).to be_a(Date)
+    end
+
+    it 'generates a call or put with a 1-5 character underlying' do
+      occ = described_class.generate
+      expect(occ.type).to eq('C').or eq('P')
+      expect(occ.underlying.length).to be_between(1, 5)
+    end
+
+    it 'generates dates that round-trip within the parser century (2000-2068)' do
+      (1..250).each do |seed|
+        expect(described_class.generate(random: Random.new(seed)).date.year).to be_between(2000, 2068)
+      end
     end
   end
 end

--- a/spec/sec_id/sedol_spec.rb
+++ b/spec/sec_id/sedol_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe SecID::SEDOL do
                   id_length: 7,
                   has_check_digit: true
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: 'B0YBKJ7',
                   dirty_id: 'b0y bkj7',

--- a/spec/sec_id/valoren_spec.rb
+++ b/spec/sec_id/valoren_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe SecID::Valoren do
                   dirty_id: '  3886335  ',
                   invalid_id: '0000'
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: '003886335',
                   canonical_id: '003886335',
@@ -212,6 +214,14 @@ RSpec.describe SecID::Valoren do
 
     it 'formats 5-digit valoren' do
       expect(described_class.new('12345').to_pretty_s).to eq('12 345')
+    end
+  end
+
+  describe '.generate' do
+    it 'generates a value within the valid length range that pads when normalized' do
+      valoren = described_class.generate
+      expect(described_class::ID_LENGTH).to cover(valoren.full_id.length)
+      expect(valoren.normalized.length).to eq(9)
     end
   end
 end

--- a/spec/sec_id/wkn_spec.rb
+++ b/spec/sec_id/wkn_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe SecID::WKN do
                   id_length: 6,
                   has_check_digit: false
 
+  it_behaves_like 'a generatable identifier'
+
   it_behaves_like 'a normalizable identifier',
                   valid_id: '514000',
                   dirty_id: '51-40-00',

--- a/spec/sec_id_spec.rb
+++ b/spec/sec_id_spec.rb
@@ -373,4 +373,38 @@ RSpec.describe SecID do
       end
     end
   end
+
+  describe '.generate' do
+    it 'returns a valid instance for a known type' do
+      result = described_class.generate(:isin)
+      expect(result).to be_a(SecID::ISIN)
+      expect(result).to be_valid
+    end
+
+    it 'raises ArgumentError for an unknown type' do
+      expect { described_class.generate(:nope) }.to raise_error(ArgumentError, /Unknown identifier type/)
+    end
+
+    it 'produces identical output for the same seed' do
+      first = described_class.generate(:isin, random: Random.new(42)).to_s
+      second = described_class.generate(:isin, random: Random.new(42)).to_s
+      expect(first).to eq(second)
+    end
+
+    it 'produces different output for a different seed' do
+      expect(described_class.generate(:isin, random: Random.new(42)).to_s)
+        .not_to eq(described_class.generate(:isin, random: Random.new(7)).to_s)
+    end
+
+    it 'is supported by every registered identifier type' do
+      described_class.identifiers.each do |klass|
+        expect(klass.generate).to be_valid
+      end
+    end
+
+    it 'raises NotImplementedError for a type that does not implement generate_body' do
+      klass = Class.new(SecID::Base)
+      expect { klass.generate }.to raise_error(NotImplementedError)
+    end
+  end
 end

--- a/spec/support/shared_examples/generatable.rb
+++ b/spec/support/shared_examples/generatable.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Shared examples for generatable identifiers.
+# Validates that `.generate` returns a valid instance and respects a seeded Random.
+RSpec.shared_examples 'a generatable identifier' do
+  describe '.generate' do
+    it 'returns an instance of the class' do
+      expect(described_class.generate).to be_a(described_class)
+    end
+
+    it 'returns a valid identifier' do
+      expect(described_class.generate).to be_valid
+    end
+
+    it 'returns a valid identifier across many seeds' do
+      (1..250).each do |seed|
+        expect(described_class.generate(random: Random.new(seed))).to be_valid
+      end
+    end
+
+    it 'produces identical output for the same seed' do
+      first = described_class.generate(random: Random.new(42)).to_s
+      second = described_class.generate(random: Random.new(42)).to_s
+      expect(first).to eq(second)
+    end
+
+    it 'produces different output for different seeds' do
+      expect(described_class.generate(random: Random.new(42)).to_s)
+        .not_to eq(described_class.generate(random: Random.new(7)).to_s)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Every identifier type can now produce a syntactically valid instance of itself for use as a test fixture — something no comparable library (including `python-stdnum`) offers. Instead of hardcoding magic valid IDs like `'US5949181045'` or copying real ones off the web (and getting the check digit wrong), ask the gem for one:

```ruby
SecID::ISIN.generate                          # => #<SecID::ISIN ...> (valid?)
SecID.generate(:cusip)                        # => #<SecID::CUSIP ...>
SecID::LEI.generate(random: Random.new(42))   # reproducible for a given seed
```

The hard part — computing a correct check digit — is exactly what a user can't do by hand, so the gem that already owns the check-digit machinery is the natural home for generating valid fixtures.

**Generated values are valid in format only — they are not real, registered securities.** Country codes, FIGI prefixes, OCC expiry dates, and CFI attributes are random. This caveat is stated at every entry point (method YARD, README, CHANGELOG).

## How it works

Generation reuses each type's existing machinery rather than adding new validation logic:

- **Check-digit types** (ISIN, CUSIP, CEI, SEDOL, FIGI, LEI, IBAN) build a random valid body and compute the real check digit through the existing `restore!` path.
- **Format-only types** (CIK, WKN, Valoren) fill their charset and length.
- **Structured types** compose from data the gem already holds: CFI category/group tables, `OCC.build`, FISN parts, and IBAN's per-country BBAN rules.

A new `Generatable` concern (included in `Base`) mirrors the existing `Checkable`/`Normalizable`/`Validatable` pattern: it owns `generate(random:)`, and each type provides a `generate_body(random)` primitive (or overrides `generate` entirely, as OCC does).

Design decisions worth calling out:

- **Determinism via an injected `Random`** — a seeded source reproduces output, with zero new dependencies (Ruby stdlib `Array#sample(random:)`).
- **Format-valid only, by design** — the safeguard is documentation, not restricting output to real-world values. Constrained generation (e.g. `generate(country_code: 'US')`) and alpha-BBAN IBAN countries are deferred follow-ups.
- **Dual API** — a per-class `.generate` plus a central `SecID.generate(type)`, mirroring the existing `SecID[]` / `SecID.parse` pairing. Unknown types raise `ArgumentError` through the same lookup.

## Testing

- New shared example `'a generatable identifier'` wired into all 13 type specs, including a 250-seed validity sweep per type so a seed-dependent regression can't slip through CI.
- Type-specific structural assertions: FIGI non-reserved prefix + vowel-free segment (with a seed that deterministically forces the resample loop), CFI valid group for its category, OCC call/put + expiry-century round-trip, FISN length bounds, IBAN all-numeric BBAN, CIK/Valoren length + padding.
- `bundle exec rake` is green: RuboCop clean, 1829 examples, 0 failures.
- Reviewed with a multi-agent + cross-model (Codex) pass. Two independent adversarial fuzzes (~1.3M and ~39k generations across thousands of seeds) found zero invalid and zero non-deterministic outputs; the handful of findings (a doc-accuracy fix, an abstract-hook `NotImplementedError` stub, an OCC 2-digit-year century fix, and the FIGI branch test) are included here.
