### PR TITLE
refactor: dissolve country-data modules into IBAN and BIC classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ### Changed
 
+- Internal `@api private` country-data modules dissolved into their owning classes, so constant names match their file paths per Ruby convention: `SecID::IBANCountryRules::COUNTRY_RULES` / `LENGTH_ONLY_COUNTRIES` are now `SecID::IBAN::COUNTRY_RULES` / `SecID::IBAN::LENGTH_ONLY_COUNTRIES`, and `SecID::BICCountryCodes::COUNTRY_CODES` is now `SecID::BIC::COUNTRY_CODES`
 - `SecID.valid?` and `SecID.parse` are faster and allocate less — `SecID.valid?` short-circuits on the first matching type instead of running a full detect-and-sort, and `SecID.parse` reuses the instance built during detection instead of instantiating the matched type a second time
 - **BREAKING:** `SecID::CFI.valid?` is now strict at the attribute level for all 14 categories (including the derivative categories `S`, `H`, `J`) — codes with attribute letters outside the ISO 10962:2021 tables, previously accepted, are now invalid (e.g. `CFI.valid?('ESZZZZ')` returns `false`). There is no leniency option, matching every other identifier type in the gem. The ActiveModel validator inherits this strictness automatically
 - **BREAKING:** `SecID::CFI.generate` now samples only letters the tables permit for each position (and honors the `ED` rule), so generated codes are always valid; it no longer emits random attribute letters

--- a/lib/sec_id/bic.rb
+++ b/lib/sec_id/bic.rb
@@ -27,8 +27,6 @@ module SecID
   #   bic.location_code  #=> "FF"
   #   bic.branch_code    #=> "500"
   class BIC < Base
-    include BICCountryCodes
-
     FULL_NAME = 'Business Identifier Code'
     ID_LENGTH = [8, 11].freeze
     EXAMPLE = 'DEUTDEFF500'

--- a/lib/sec_id/bic/country_codes.rb
+++ b/lib/sec_id/bic/country_codes.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
 module SecID
-  # Recognized country codes for BIC (ISO 9362).
-  #
-  # The set is the ISO 3166-1 alpha-2 officially-assigned codes, extended with
-  # SWIFT-recognized codes that are not (yet) in ISO 3166-1 — currently `XK`
-  # (Kosovo), which SWIFT assigns BICs under.
-  #
-  # @api private
-  module BICCountryCodes
+  class BIC < Base
     # Frozen set of country codes accepted in a BIC's positions 5-6.
     #
+    # The set is the ISO 3166-1 alpha-2 officially-assigned codes, extended with
+    # SWIFT-recognized codes that are not (yet) in ISO 3166-1 — currently `XK`
+    # (Kosovo), which SWIFT assigns BICs under.
+    #
+    # @api private
     # @see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
     # rubocop:disable Metrics/CollectionLiteralLength
     COUNTRY_CODES = Set.new(

--- a/lib/sec_id/iban.rb
+++ b/lib/sec_id/iban.rb
@@ -19,7 +19,6 @@ module SecID
   #   SecID::IBAN.restore!('DE00370400440532013000')  #=> #<SecID::IBAN>
   class IBAN < Base
     include Checkable
-    include IBANCountryRules
 
     FULL_NAME = 'International Bank Account Number'
     ID_LENGTH = (15..34)

--- a/lib/sec_id/iban/country_rules.rb
+++ b/lib/sec_id/iban/country_rules.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 module SecID
-  # Country-specific BBAN validation rules for IBAN.
-  #
-  # @api private
-  # rubocop:disable Metrics/ModuleLength
-  module IBANCountryRules
+  # rubocop:disable Metrics/ClassLength
+  class IBAN < Base
     # Country-specific BBAN rules for EU/EEA countries
     # Each entry defines:
     #   - :length => total BBAN length
@@ -15,6 +12,8 @@ module SecID
     # Sources:
     # - https://en.wikipedia.org/wiki/International_Bank_Account_Number
     # - https://www.swift.com/standards/data-standards/iban-international-bank-account-number
+    #
+    # @api private
     COUNTRY_RULES = {
       # Austria - 16 chars: 5-digit bank code + 11-digit account
       'AT' => {
@@ -224,6 +223,8 @@ module SecID
 
     # Countries where only length validation is performed (non-EU/EEA countries)
     # Format: country_code => expected BBAN length
+    #
+    # @api private
     LENGTH_ONLY_COUNTRIES = {
       'AD' => 20, # Andorra
       'AE' => 19, # UAE
@@ -264,5 +265,5 @@ module SecID
       'XK' => 16  # Kosovo
     }.freeze
   end
-  # rubocop:enable Metrics/ModuleLength
+  # rubocop:enable Metrics/ClassLength
 end

--- a/sig/sec_id/bic.rbs
+++ b/sig/sec_id/bic.rbs
@@ -1,8 +1,6 @@
 module SecID
   # Business Identifier Code (BIC / SWIFT code).
   class BIC < Base
-    include BICCountryCodes
-
     FULL_NAME: String
     ID_LENGTH: Array[Integer]
     EXAMPLE: String

--- a/sig/sec_id/bic/country_codes.rbs
+++ b/sig/sec_id/bic/country_codes.rbs
@@ -1,8 +1,5 @@
 module SecID
-  # Recognized country codes for BIC (ISO 9362).
-  #
-  # @api private
-  module BICCountryCodes
+  class BIC < Base
     COUNTRY_CODES: Set[String]
   end
 end

--- a/sig/sec_id/iban.rbs
+++ b/sig/sec_id/iban.rbs
@@ -3,14 +3,13 @@ module SecID
   class IBAN < Base
     include Checkable
     extend Checkable::ClassMethods
-    include IBANCountryRules
 
     FULL_NAME: String
     ID_LENGTH: ::Range[Integer]
     EXAMPLE: String
     VALID_CHARS_REGEX: ::Regexp
     ID_REGEX: ::Regexp
-    NUMERIC_COUNTRY_RULES: Array[[String, IBANCountryRules::rule]]
+    NUMERIC_COUNTRY_RULES: Array[[String, rule]]
 
     def self.supported_countries: () -> Array[String]
 
@@ -30,7 +29,7 @@ module SecID
     def calculate_check_digit: () -> Integer
     private def self.generate_body: (Random random) -> String
     def valid_bban_format?: () -> bool
-    def country_rule: () -> IBANCountryRules::rule?
+    def country_rule: () -> rule?
     def known_country?: () -> bool
     def to_s: () -> String
     def to_pretty_s: () -> String?

--- a/sig/sec_id/iban/country_rules.rbs
+++ b/sig/sec_id/iban/country_rules.rbs
@@ -1,8 +1,5 @@
 module SecID
-  # Country-specific BBAN validation rules for IBAN.
-  #
-  # @api private
-  module IBANCountryRules
+  class IBAN < Base
     # `{ length: Integer, format: Regexp, components?: {name => [start, length]} }`, but
     # the nested literal infers as a broad Hash, so it is modelled loosely.
     type rule = Hash[Symbol, untyped]

--- a/spec/sec_id/iban_spec.rb
+++ b/spec/sec_id/iban_spec.rb
@@ -569,8 +569,8 @@ RSpec.describe SecID::IBAN do
     end
 
     it 'has size matching COUNTRY_RULES + LENGTH_ONLY_COUNTRIES' do
-      expected = (SecID::IBANCountryRules::COUNTRY_RULES.keys +
-                  SecID::IBANCountryRules::LENGTH_ONLY_COUNTRIES.keys).uniq.size
+      expected = (SecID::IBAN::COUNTRY_RULES.keys +
+                  SecID::IBAN::LENGTH_ONLY_COUNTRIES.keys).uniq.size
       expect(described_class.supported_countries.size).to eq(expected)
     end
   end


### PR DESCRIPTION
## Description

Constant names now follow Ruby's path ↔ namespace convention: `SecID::IBAN::COUNTRY_RULES`, `SecID::IBAN::LENGTH_ONLY_COUNTRIES`, and `SecID::BIC::COUNTRY_CODES` replace the top-level `SecID::IBANCountryRules` / `SecID::BICCountryCodes` wrapper modules, whose names didn't match their file locations (`sec_id/iban/country_rules.rb`, `sec_id/bic/country_codes.rb`).

The wrapper modules existed only to hold data constants, so they are dissolved entirely rather than renamed — the constants sit directly on the reopened owning classes and the `include` lines are gone, removing a layer of indirection (`SecID::BIC::CountryCodes::COUNTRY_CODES` would have been stutter). Both modules were `@api private`, so there is no public API change and no deprecation shim is needed. RBS signatures mirror the move: the `rule` type alias now lives on `IBAN` itself.

Verified with the full gate: RuboCop clean, `rbs validate`, 2003 specs passing, Steep strict with zero errors, type coverage at the pinned 118 baseline, and `rake rbs:test` (runtime signature verification) green.

## Type of Change

- [x] Refactoring (no behavior change)

## Checklist

- [x] Tests pass (`bundle exec rspec`)
- [x] RuboCop clean (`bundle exec rubocop`)
- [x] CHANGELOG.md updated (under `[Unreleased]`)
- [x] Documentation updated (if public API changed) — no public API change; CLAUDE.md/README verified free of stale references
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
