### PR TITLE
refactor: move type_key and detection_priority onto Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `SecID::Base.type_key` — the memoized class-level registry symbol for an identifier type, joining the existing `short_name` / `full_name` / `id_length` metadata surface. It round-trips through the registry: `SecID[SecID::ISIN.type_key] == SecID::ISIN`. It is now the single authority for that symbol; the registry, `#to_h`, `SecID.explain`, the ActiveModel validator, the detector, and the scanner all read it instead of each deriving it from the class name
+
 ## [6.0.0] - 2026-07-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ All identifier classes inherit from `SecID::Base` (`lib/sec_id/base.rb`), a thin
 - `Generatable` — generation: `.generate(random:)`, `random_string(charset, length, random:)` helper, `ALPHA`/`DIGITS`/`ALPHANUMERIC` charset constants
 
 Base itself keeps:
-- Class-level metadata methods: `short_name`, `full_name`, `id_length`, `example`, `has_check_digit?`
+- Class-level metadata methods: `type_key` (the registry symbol — single authority, read by the registry, `to_h`, `explain`, the validator, `Detector`, and `Scanner`), `short_name`, `full_name`, `id_length`, `example`, `has_check_digit?`, and the `@api private` `detection_priority` (composite specificity sort key: check-digit rank, `length_specificity`, registration order — `Float::INFINITY` for an unregistered class)
 - `attr_reader :full_id, :identifier`
 - `inherited` hook (auto-registration)
 - `initialize` (abstract, raises `NotImplementedError`)
@@ -91,7 +91,7 @@ Identifier classes auto-register via `Base.inherited`. Access them through:
 2. **Length lookup** — pre-computed `Hash{Integer => Array<Class>}` from `ID_LENGTH` constants
 3. **Charset pre-filter** — survivors filtered by `VALID_CHARS_REGEX` before calling `valid?`
 
-Specificity sort: check-digit types first, then smaller length range, then load order.
+Specificity sort: reads each class's `Base.detection_priority` (check-digit types first, then smaller length range, then load order).
 
 Fast paths bypass the full sort: `#matches?` (used by `SecID.valid?`) short-circuits on the first valid candidate; `#first_match` (used by `SecID.parse`) builds the winning instance once and selects it via `min_by`, avoiding a second instantiation.
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ SecID.identifiers                         # => [SecID::ISIN, SecID::CUSIP, ...]
 SecID.identifiers.map(&:short_name)       # => ["ISIN", "CUSIP", "SEDOL", ...]
 
 # Query metadata
+SecID::ISIN.type_key                      # => :isin  (SecID[SecID::ISIN.type_key] == SecID::ISIN)
 SecID::ISIN.short_name                    # => "ISIN"
 SecID::ISIN.full_name                     # => "International Securities Identification Number"
 SecID::ISIN.id_length                     # => 12

--- a/lib/sec_id.rb
+++ b/lib/sec_id.rb
@@ -85,7 +85,7 @@ module SecID
     # @return [Hash] hash with :input and :candidates keys
     def explain(str, types: nil)
       input = str.to_s.strip
-      target_keys = types || identifier_list.map { |k| k.short_name.downcase.to_sym }
+      target_keys = types || identifier_list.map(&:type_key)
       candidates = target_keys.map do |key|
         instance = self[key].new(input)
         { type: key, valid: instance.valid?, errors: instance.errors.details }
@@ -143,8 +143,7 @@ module SecID
 
     # @return [void]
     def register_identifier(klass)
-      key = klass.name.split('::').last.downcase.to_sym
-      identifier_map[key] = klass
+      identifier_map[klass.type_key] = klass
       identifier_list << klass
       @detector = nil
       @scanner = nil

--- a/lib/sec_id/active_model.rb
+++ b/lib/sec_id/active_model.rb
@@ -93,7 +93,7 @@ class SecIdValidator < ActiveModel::EachValidator
   #
   # @return [Array<Symbol>]
   def candidate_types
-    configured_types || SecID.identifiers.map { |klass| klass.short_name.downcase.to_sym }
+    configured_types || SecID.identifiers.map(&:type_key)
   end
 
   # sec_id's specific failure reason, only when `details: true` and a single `type:` is set;

--- a/lib/sec_id/base.rb
+++ b/lib/sec_id/base.rb
@@ -50,6 +50,22 @@ module SecID
     attr_reader :identifier
 
     class << self
+      # The type's registry symbol: `SecID[SecID::ISIN.type_key] == SecID::ISIN`.
+      #
+      # @return [Symbol] the registry key (e.g. :isin, :cusip)
+      def type_key = @type_key ||= short_name.downcase.to_sym
+
+      # Composite sort key ranking detection specificity: check-digit types first,
+      # then narrower length range, then registration order. A class the registry
+      # never saw sorts last.
+      #
+      # @api private
+      # @return [Array] frozen [check-digit rank, length specificity, registration order]
+      def detection_priority
+        @detection_priority ||=
+          [has_check_digit? ? 0 : 1, length_specificity, SecID.identifiers.index(self) || Float::INFINITY].freeze
+      end
+
       # @return [String] the unqualified class name (e.g. "ISIN", "CUSIP")
       def short_name = @short_name ||= name.split('::').last
 
@@ -114,7 +130,7 @@ module SecID
     # @return [Hash] hash with :type, :full_id, :normalized, :valid, and :components keys
     def to_h
       {
-        type: self.class.short_name.downcase.to_sym,
+        type: self.class.type_key,
         full_id: full_id,
         normalized: valid? ? normalized : nil,
         valid: valid?,

--- a/lib/sec_id/detector.rb
+++ b/lib/sec_id/detector.rb
@@ -58,7 +58,7 @@ module SecID
 
       candidates = filter_candidates(input.upcase)
       matches = candidates.filter_map { |klass| (i = klass.new(input)).valid? ? i : nil }
-      matches.min_by { |instance| @priority_for[instance.class] }
+      matches.min_by { |instance| instance.class.detection_priority }
     end
 
     private
@@ -81,16 +81,14 @@ module SecID
     # @return [Array<Symbol>]
     def validate_and_sort(input, candidates)
       matches = candidates.select { |klass| klass.valid?(input) }
-      matches.sort_by! { |klass| @priority_for[klass] }
-      matches.map! { |klass| @key_for[klass] }
+      matches.sort_by!(&:detection_priority)
+      matches.map!(&:type_key)
     end
 
     # @return [void]
     def precompute
       build_discriminator_sets
       build_length_table
-      build_priority_table
-      build_key_table
     end
 
     # Classifies types by which special characters their VALID_CHARS_REGEX accepts.
@@ -112,27 +110,6 @@ module SecID
         klass.length_values.each { |len| @candidates_by_length[len] << klass }
       end
       @candidates_by_length.each_value(&:freeze)
-    end
-
-    # Builds composite sort keys: check-digit types first, then smaller range, then load order.
-    #
-    # @return [void]
-    def build_priority_table
-      @priority_for = {}
-      @classes.each_with_index do |klass, index|
-        check_digit_rank = klass.has_check_digit? ? 0 : 1
-        @priority_for[klass] = [check_digit_rank, klass.length_specificity, index].freeze
-      end
-      @priority_for.freeze
-    end
-
-    # Maps each class to its registry symbol key.
-    #
-    # @return [void]
-    def build_key_table
-      @key_for = {}
-      @classes.each { |klass| @key_for[klass] = klass.short_name.downcase.to_sym }
-      @key_for.freeze
     end
 
     # Stage 1: route strings with special characters to the only types that accept them.

--- a/lib/sec_id/scanner.rb
+++ b/lib/sec_id/scanner.rb
@@ -51,34 +51,29 @@ module SecID
     private
 
     # @return [void]
-    def precompute # rubocop:disable Metrics/AbcSize
-      build_key_table
-      build_priority_table
+    def precompute
+      build_candidate_partitions
+      build_length_table
+    end
+
+    # Splits the registered classes by which CANDIDATE_RE group routes to them.
+    #
+    # @return [void]
+    def build_candidate_partitions
       @fisn_classes = @classes.select { |k| k.short_name == 'FISN' }
       @occ_classes = @classes.select { |k| k.short_name == 'OCC' }
       @simple_classes = @classes - @fisn_classes - @occ_classes
+    end
+
+    # Builds a Hash mapping each possible length to the classes that accept it.
+    #
+    # @return [void]
+    def build_length_table
       @candidates_by_length = Hash.new { |h, k| h[k] = [] }
       @classes.each do |klass|
         klass.length_values.each { |len| @candidates_by_length[len] << klass }
       end
       @candidates_by_length.each_value(&:freeze)
-    end
-
-    # @return [void]
-    def build_key_table
-      @key_for = {}
-      @classes.each { |klass| @key_for[klass] = klass.short_name.downcase.to_sym }
-      @key_for.freeze
-    end
-
-    # @return [void]
-    def build_priority_table
-      @priority_for = {}
-      @classes.each_with_index do |klass, index|
-        check_digit_rank = klass.has_check_digit? ? 0 : 1
-        @priority_for[klass] = [check_digit_rank, klass.length_specificity, index].freeze
-      end
-      @priority_for.freeze
     end
 
     # @param input [String]
@@ -123,7 +118,7 @@ module SecID
       return unless best
 
       end_pos = start_pos + raw.length
-      Match.new(type: @key_for[best], raw: raw, range: start_pos...end_pos, identifier: best.new(cleaned))
+      Match.new(type: best.type_key, raw: raw, range: start_pos...end_pos, identifier: best.new(cleaned))
     end
 
     # @return [Class, nil]
@@ -134,7 +129,7 @@ module SecID
       return if candidates.empty?
 
       validated = candidates.select { |k| cleaned.match?(k::VALID_CHARS_REGEX) && k.valid?(cleaned) }
-      validated.min_by { |k| @priority_for[k] }
+      validated.min_by(&:detection_priority)
     end
   end
 end

--- a/sig/sec_id/base.rbs
+++ b/sig/sec_id/base.rbs
@@ -33,6 +33,9 @@ module SecID
     # RBS forbids narrowing an inherited ivar's type.
     def identifier: () -> String?
 
+    def self.type_key: () -> Symbol
+    # `@api private` in YARD, but public here: Detector and Scanner call it from outside.
+    def self.detection_priority: () -> Array[Integer | Float | nil]
     def self.short_name: () -> String
     def self.full_name: () -> String
     def self.id_length: () -> (Integer | ::Range[Integer] | ::Array[Integer])
@@ -68,5 +71,7 @@ module SecID
     @identifier: untyped
     self.@short_name: String
     self.@has_check_digit: bool
+    self.@type_key: Symbol
+    self.@detection_priority: Array[Integer | Float | nil]
   end
 end

--- a/sig/sec_id/detector.rbs
+++ b/sig/sec_id/detector.rbs
@@ -3,8 +3,6 @@ module SecID
   #
   # @api private
   class Detector
-    type priority = Array[Integer | Float | nil]
-
     def initialize: (Array[singleton(Base)] identifier_list) -> void
     def call: (SecID::input str) -> Array[Symbol]
     def matches?: (SecID::input str) -> bool
@@ -17,8 +15,6 @@ module SecID
     def precompute: () -> void
     def build_discriminator_sets: () -> void
     def build_length_table: () -> void
-    def build_priority_table: () -> void
-    def build_key_table: () -> void
     def stage1_special_chars: (String upcased) -> Array[singleton(Base)]?
     def stage2_length: (Integer length) -> Array[singleton(Base)]
     def stage3_charset: (String upcased, Array[singleton(Base)] candidates) -> Array[singleton(Base)]
@@ -29,7 +25,5 @@ module SecID
     @space_only_types: Array[singleton(Base)]
     @special_types: Array[singleton(Base)]
     @candidates_by_length: Hash[Integer, Array[singleton(Base)]]
-    @priority_for: Hash[singleton(Base), priority]
-    @key_for: Hash[singleton(Base), Symbol]
   end
 end

--- a/sig/sec_id/scanner.rbs
+++ b/sig/sec_id/scanner.rbs
@@ -28,8 +28,8 @@ module SecID
     private
 
     def precompute: () -> void
-    def build_key_table: () -> void
-    def build_priority_table: () -> void
+    def build_candidate_partitions: () -> void
+    def build_length_table: () -> void
     def scan_text: (String input, Array[singleton(Base)] target_classes) { (Match) -> void } -> void
     def identify_candidate: (untyped match_data, Array[singleton(Base)] target_classes) -> Match?
     def try_classes: (String raw, String cleaned, Integer start_pos, Array[singleton(Base)] classes) -> Match?
@@ -40,7 +40,5 @@ module SecID
     @occ_classes: Array[singleton(Base)]
     @simple_classes: Array[singleton(Base)]
     @candidates_by_length: Hash[Integer, Array[singleton(Base)]]
-    @priority_for: Hash[singleton(Base), Array[Integer | Float | nil]]
-    @key_for: Hash[singleton(Base), Symbol]
   end
 end

--- a/spec/sec_id/base_spec.rb
+++ b/spec/sec_id/base_spec.rb
@@ -61,6 +61,56 @@ RSpec.describe SecID::Base do
     it '.has_check_digit? returns false for non-Checkable types' do
       expect(SecID::CIK.has_check_digit?).to be(false)
     end
+
+    it '.type_key returns the registry symbol' do
+      expect(SecID::ISIN.type_key).to eq(:isin)
+    end
+  end
+
+  describe '.type_key' do
+    it 'round-trips through SecID[] for every registered type' do
+      SecID.identifiers.each { |klass| expect(SecID[klass.type_key]).to be(klass) }
+    end
+  end
+
+  describe '.detection_priority' do
+    let(:unregistered) do
+      klass = Class.new(described_class)
+      klass.const_set(:ID_LENGTH, 9)
+      klass
+    end
+
+    it 'ranks check-digit types ahead of non-check-digit types' do
+      expect(SecID::ISIN.detection_priority[0]).to eq(0)
+      expect(SecID::CIK.detection_priority[0]).to eq(1)
+    end
+
+    it 'uses length_specificity as the second element' do
+      expect(SecID::ISIN.detection_priority[1]).to eq(1)
+      expect(SecID::BIC.detection_priority[1]).to eq(2)
+    end
+
+    it 'uses registration order as the third element' do
+      keys = SecID.identifiers.map { |klass| klass.detection_priority[2] }
+      expect(keys).to eq((0...SecID.identifiers.size).to_a)
+    end
+
+    it 'sorts an unregistered class last without raising' do
+      expect(unregistered.detection_priority[2]).to eq(Float::INFINITY)
+      expect(unregistered.detection_priority <=> SecID::ISIN.detection_priority).to eq(1)
+    end
+
+    it 'returns a memoized frozen tuple' do
+      expect(SecID::ISIN.detection_priority).to be_frozen.and be(SecID::ISIN.detection_priority)
+    end
+  end
+
+  describe '#to_h' do
+    it 'emits type_key as the :type value for every registered type' do
+      SecID.identifiers.each do |klass|
+        expect(klass.new(klass.example).to_h[:type]).to eq(klass.type_key)
+      end
+    end
   end
 
   describe '#== / #eql? / #hash' do

--- a/spec/sec_id/base_spec.rb
+++ b/spec/sec_id/base_spec.rb
@@ -74,9 +74,11 @@ RSpec.describe SecID::Base do
   end
 
   describe '.detection_priority' do
+    # Mirrors ISIN's check-digit rank and ID_LENGTH so a comparison against ISIN ties on the
+    # first two elements and is decided by the third — the only slot that can hold Infinity.
     let(:unregistered) do
-      klass = Class.new(described_class)
-      klass.const_set(:ID_LENGTH, 9)
+      klass = Class.new(described_class) { include SecID::Checkable }
+      klass.const_set(:ID_LENGTH, 12)
       klass
     end
 
@@ -97,6 +99,7 @@ RSpec.describe SecID::Base do
 
     it 'sorts an unregistered class last without raising' do
       expect(unregistered.detection_priority[2]).to eq(Float::INFINITY)
+      expect(unregistered.detection_priority.take(2)).to eq(SecID::ISIN.detection_priority.take(2))
       expect(unregistered.detection_priority <=> SecID::ISIN.detection_priority).to eq(1)
     end
 

--- a/spec/sec_id/base_spec.rb
+++ b/spec/sec_id/base_spec.rb
@@ -109,10 +109,12 @@ RSpec.describe SecID::Base do
   end
 
   describe '#to_h' do
-    it 'emits type_key as the :type value for every registered type' do
-      SecID.identifiers.each do |klass|
-        expect(klass.new(klass.example).to_h[:type]).to eq(klass.type_key)
-      end
+    # Expected symbols are hardcoded, not derived from type_key: comparing to_h[:type]
+    # against klass.type_key would be x == x, since to_h returns self.class.type_key.
+    it 'emits the registry symbol as the :type value for every registered type' do
+      expected = %i[isin cusip sedol figi lei iban cik occ wkn valoren cei cfi fisn bic dti]
+      emitted = SecID.identifiers.map { |klass| klass.new(klass.example).to_h[:type] }
+      expect(emitted).to eq(expected)
     end
   end
 

--- a/spec/sec_id/detector_spec.rb
+++ b/spec/sec_id/detector_spec.rb
@@ -235,9 +235,7 @@ RSpec.describe SecID::Detector do
 
       it 'sets specificity to the count of discrete lengths' do
         # Base.length_specificity: a discrete [8, 11] contributes size 2.
-        # Scanner's build_priority_table calls the same helper.
-        priority = described_class.new([stub]).instance_variable_get(:@priority_for)
-        expect(priority[stub][1]).to eq(2)
+        expect(stub.detection_priority[1]).to eq(2)
       end
     end
 


### PR DESCRIPTION
Implements `docs/plans/2026-07-09-001-refactor-detector-scanner-precompute-dedup-plan.md`.

## What

Six sites in `lib/` independently derived a type's registry symbol from its class name, and `build_priority_table` was byte-identical in `Detector` and `Scanner` — a domain decision (check-digit types first, then narrower length range, then registration order) duplicated across two files where a one-sided edit would not reliably fail the specs.

Both are facts about the type, so they now live on the type:

- `SecID::Base.type_key` — public, memoized, the registry symbol. `SecID[SecID::ISIN.type_key] == SecID::ISIN`.
- `SecID::Base.detection_priority` — `@api private`, memoized, the composite specificity tuple.

Every consumer reads them: `register_identifier`, `SecID.explain`, `Base#to_h`, `SecIdValidator#candidate_types`, `Detector`, `Scanner`. `build_key_table` and `build_priority_table` are gone from both private classes, along with their `@key_for`/`@priority_for` ivars and sig entries. `Scanner#precompute` splits into `build_candidate_partitions` + `build_length_table` and no longer carries `rubocop:disable Metrics/AbcSize`.

Registration order is derived lazily as `SecID.identifiers.index(self) || Float::INFINITY`, so an anonymous `Class.new(SecID::Base)` that never entered the registry sorts last rather than putting a `nil` in the tuple and making `min_by` raise.

Per the plan, `candidates_by_length` stays per-class — it is a table over all registered classes that no single class can own, and its build loop encodes no domain decision.

## Behavior

Observationally invisible apart from the new `type_key` method. No detection, parsing, scanning, or serialization result changes. `lib/` is net **−13 lines** (40 insertions, 53 deletions).

## Verification

| Gate | Result |
|---|---|
| `bundle exec rubocop` | clean, no inline disable in `scanner.rb` |
| `bundle exec rake rbs` | valid |
| `bundle exec rake steep` | 0 errors |
| `bundle exec rake steep:coverage` | 119 untyped calls — baseline unchanged, not raised |
| `bundle exec rake rbs:test` | 0 failures |
| `bundle exec rspec` | 2142 examples, 0 failures |
| `BUNDLE_GEMFILE=gemfiles/rails_8.0.gemfile bundle exec rspec` | 0 failures |
| `bundle exec rake yard:stats` | 100% documented |

### Throughput (`bundle exec rake bench`)

The one measurable risk was a `Hash#[]` lookup inside `sort_by`/`min_by` becoming a memoized method dispatch. It does not show above run-to-run variance. Two post-change runs against the `main` baseline (i/s, higher is better):

| Benchmark | `main` | after (run 1) | after (run 2) |
|---|---|---|---|
| `SecID.valid?` (unknown → detector) | 156.1k ± 9.1% | 161.9k ± 6.0% | 166.7k ± 3.0% |
| `SecID.detect` | 140.4k ± 1.9% | 138.0k ± 2.5% | 134.8k ± 10.5% |
| `SecID.parse` | 138.7k ± 1.9% | 133.1k ± 6.8% | 140.6k ± 2.2% |
| `SecID.extract` (paragraph) | 5.731k ± 11.4% | 5.632k ± 11.4% | 6.051k ± 3.2% |

Every deviation sits inside the reported error bars, and run 2 beats the baseline on three of the four. Allocations per call are byte-identical to `main` across all nine benchmarks.

## Definition of Done

- `git grep 'short_name.downcase.to_sym' lib/` → exactly one hit, the body of `type_key`
- `git grep 'has_check_digit? ? 0 : 1' lib/` → exactly one hit, in `base.rb`
- No `@key_for` or `@priority_for` anywhere in `lib/`, `sig/`, or `spec/`
- `STEEP_UNTYPED_BASELINE` not raised
- No version bump; CHANGELOG entry lands under `[Unreleased]` → `Added`

## Notes

- The one spec assertion that reached into `Detector`'s internals (`instance_variable_get(:@priority_for)`) is rewritten as a direct read of `stub.detection_priority`, per the plan's KTD5. The sibling length-table example is untouched.
- `detection_priority` is declared publicly in `sig/sec_id/base.rbs` despite its `@api private` YARD tag — `Detector` and `Scanner` call it from outside the class, and Steep does not read YARD. The gem already ships `@api private` `Detector`/`Scanner` publicly in `sig/`.
- Deferred, as the plan scopes it: reconciling `Scanner`'s hardcoded `short_name == 'FISN'`/`'OCC'` routing with `Detector`'s charset probing.