### PR TITLE
feat: add deconstruct_keys for case/in pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ### Added
 
+- `SecID::Base#deconstruct_keys` — every identifier now destructures in `case/in` patterns, exposing the same parsed fields `#to_h` reports under `:components`. The `keys` argument is ignored, no new keys are introduced, and validity is not part of the protocol: `SecID.parse` returning `nil` remains the validity guard, and an instance built from unparseable input binds `nil` for each component. No `deconstruct` (array-pattern) method is defined
 - `SecID::Base.type_key` — the memoized class-level registry symbol for an identifier type, joining the existing `short_name` / `full_name` / `id_length` metadata surface. It round-trips through the registry: `SecID[SecID::ISIN.type_key] == SecID::ISIN`. It is now the single authority for that symbol; the registry, `#to_h`, `SecID.explain`, the ActiveModel validator, the detector, and the scanner all read it instead of each deriving it from the class name
 
 ## [6.0.0] - 2026-07-08

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Base itself keeps:
 - `initialize` (abstract, raises `NotImplementedError`)
 - `to_h` (returns `{ type:, full_id:, normalized:, valid:, components: }`)
 - `as_json(*)` — delegates to `to_h` for JSON serialization compatibility
+- `deconstruct_keys(_keys)` — returns `components` so every type destructures in `case/in`; the `keys` argument is ignored, validity is not consulted (unparseable input binds `nil` per key), and no `deconstruct` exists
 - `==`, `eql?`, `hash` — value equality based on `comparison_id` (type + normalized form); instances usable as Hash keys and in Sets
 - `components` (private, returns `{}` — subclasses override with type-specific attributes)
 - `parse` (private, regex matching + `@full_id` assignment)
@@ -176,7 +177,7 @@ Each identifier type (`lib/sec_id/*.rb`) implements:
 - `ID_REGEX` constant with named capture groups for parsing
 - `initialize` that calls `parse` and extracts components
 - Type-specific attributes (e.g., `country_code`, `nsin` for ISIN; `cusip6`, `issue` for CUSIP)
-- Private `components` method returning a hash of parsed attributes (for `#to_h` serialization); classes with no type-specific attributes (CIK, WKN, Valoren) inherit the empty `{}` default
+- Private `components` method returning a hash of parsed attributes (read by both `#to_h` and `#deconstruct_keys`); classes with no type-specific attributes (CIK, WKN, Valoren) inherit the empty `{}` default
 
 **Classes with check digits** (ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CEI, DTI):
 - Include `Checkable` concern

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [Text Scanning](#text-scanning) - find identifiers in freeform text
   - [Debugging Detection](#debugging-detection) - understand why strings match or don't
   - [Structured Validation](#structured-validation) - detailed error codes and messages
+  - [Pattern Matching](#pattern-matching) - destructure identifiers with `case/in`
   - [Generating Test Fixtures](#generating-test-fixtures) - produce valid identifiers for tests
   - [ISIN](#isin) - International Securities Identification Number
   - [CUSIP](#cusip) - Committee on Uniform Securities Identification Procedures
@@ -75,6 +76,7 @@ All identifier classes provide `valid?`, `errors`, `validate`, `validate!` metho
 **All identifiers** support hash serialization:
 - `#to_h` - returns a hash with `:type`, `:full_id`, `:normalized`, `:valid`, and `:components` keys
 - `#as_json` - same as `#to_h`, for JSON serialization compatibility (Rails, `JSON.generate`, etc.)
+- `#deconstruct_keys` - exposes `:components` for [pattern matching](#pattern-matching) with `case/in`
 
 ```ruby
 SecID::ISIN.new('US5949181045').to_h
@@ -261,6 +263,48 @@ SecID::FIGI.new('BSG000BLNNH6').validate!
 # Class-level convenience method (returns the instance)
 isin = SecID::ISIN.validate!('US5949181045')  # => #<SecID::ISIN>
 ```
+
+### Pattern Matching
+
+Every identifier destructures in `case/in` via its parsed components. Since `SecID.parse` returns `nil` for
+anything invalid, an `in nil` branch is a complete validity guard:
+
+```ruby
+case SecID.parse(input)
+in SecID::ISIN[country_code: 'US', nsin:]  then "US security #{nsin}"
+in SecID::ISIN[country_code:]              then "foreign security from #{country_code}"
+in SecID::OCC[underlying:, type:, strike_mills:] then "#{type} option on #{underlying}"
+in nil                                     then 'not a valid identifier'
+end
+```
+
+`SecID::Match` is a `Data`, so scan results destructure one layer up and nest into the identifier they wrap:
+
+```ruby
+SecID.extract('AAPL ISIN US0378331005').each do |match|
+  case match
+  in { type: :isin, identifier: SecID::ISIN[country_code: 'US'] } then puts 'US ISIN found'
+  else next
+  end
+end
+```
+
+The keys are exactly the `:components` of `#to_h`, and destructuring never consults
+`valid?`. An instance built directly from unparseable input therefore binds `nil` for every component, the same shape
+`to_h` reports:
+
+```ruby
+SecID::ISIN.new('GARBAGE') => { country_code:, nsin: }
+country_code # => nil
+nsin         # => nil
+```
+
+CIK, WKN, and Valoren have no sub-fields: they match a bare `in SecID::CIK` but no keyed pattern. Array patterns
+(`deconstruct`) are not supported.
+
+Watch the `:type` key: on a `SecID::Match` it is the registry symbol (`:occ`), while on an `OCC` instance it is the
+OSI option type (`'C'` or `'P'`), so `in SecID::OCC[type: :occ]` never matches. Other types have no `:type` component
+at all — `#to_h`'s envelope keys (`:type`, `:full_id`, `:normalized`, `:valid`) are not part of the pattern surface.
 
 ### Generating Test Fixtures
 

--- a/lib/sec_id/base.rb
+++ b/lib/sec_id/base.rb
@@ -145,6 +145,20 @@ module SecID
       to_h
     end
 
+    # Exposes the parsed components for `case/in` destructuring. Validity is not part of
+    # the protocol: components of unparseable input are `nil`, and `SecID.parse` returning
+    # `nil` is the validity guard.
+    #
+    # @param _keys [Array<Symbol>, nil] the keys the pattern requests; ignored
+    # @return [Hash] the parsed components
+    #
+    # @example
+    #   case SecID.parse('US5949181045')
+    #   in SecID::ISIN[country_code:, nsin:] then [country_code, nsin]
+    #   in nil then :invalid
+    #   end #=> ['US', '594918104']
+    def deconstruct_keys(_keys) = components
+
     protected
 
     # @return [String]

--- a/sig/sec_id/base.rbs
+++ b/sig/sec_id/base.rbs
@@ -52,6 +52,7 @@ module SecID
     def hash: () -> Integer
     def to_h: () -> Hash[Symbol, untyped]
     def as_json: (*untyped) -> Hash[Symbol, untyped]
+    def deconstruct_keys: (::Array[Symbol]? _keys) -> Hash[Symbol, untyped]
 
     # Check-digit surface. Only the types that `include Checkable` implement these
     # (they raise/NoMethodError otherwise); declared on Base so `Generatable#generate`

--- a/spec/sec_id/base_spec.rb
+++ b/spec/sec_id/base_spec.rb
@@ -118,6 +118,77 @@ RSpec.describe SecID::Base do
     end
   end
 
+  describe '#deconstruct_keys' do
+    # AE1: a valid identifier through SecID.parse destructures to its components.
+    it 'binds components from a parsed identifier' do
+      case SecID.parse('US5949181045')
+      in SecID::ISIN[country_code:, nsin:]
+        expect([country_code, nsin]).to eq(%w[US 594918104])
+      end
+    end
+
+    # AE2: SecID.parse is the validity channel; an invalid check digit yields nil.
+    it 'falls to the nil branch for an identifier SecID.parse rejects' do
+      matched =
+        case SecID.parse('US6949181045')
+        in SecID::ISIN then :isin
+        in nil then :nil
+        end
+
+      expect(matched).to eq(:nil)
+    end
+
+    # AE3: the protocol does not gate on valid?.
+    it 'destructures an instance with an invalid check digit' do
+      isin = SecID::ISIN.new('US6949181045')
+      expect(isin).not_to be_valid
+      expect(isin.deconstruct_keys(nil)).to eq(country_code: 'US', nsin: '694918104', check_digit: 5)
+    end
+
+    # AE4: unparseable input binds nil, mirroring MatchData#deconstruct_keys.
+    it 'binds nil for components of unparseable input' do
+      case SecID::ISIN.new('GARBAGE')
+      in SecID::ISIN[nsin:]
+        expect(nsin).to be_nil
+      end
+    end
+
+    # AE6: Match is a Data, and the identifier it wraps now destructures too.
+    it 'destructures nested inside a scan result' do
+      match = SecID.extract('holding US5949181045 today').first
+
+      case match
+      in { type: :isin, identifier: SecID::ISIN[country_code:] }
+        expect(country_code).to eq('US')
+      end
+    end
+
+    it 'ignores the keys argument' do
+      isin = SecID::ISIN.new('US5949181045')
+      expect(isin.deconstruct_keys([:country_code])).to eq(isin.deconstruct_keys(nil))
+    end
+
+    it 'does not define deconstruct, so array patterns do not match' do
+      expect(SecID::ISIN.new('US5949181045')).not_to respond_to(:deconstruct)
+      expect do
+        case SecID::ISIN.new('US5949181045')
+        in SecID::ISIN[_first]
+          nil
+        end
+      end.to raise_error(NoMatchingPatternError)
+    end
+
+    it 'returns a fresh hash on every call' do
+      isin = SecID::ISIN.new('US5949181045')
+      isin.deconstruct_keys(nil)[:country_code] = 'ZZ'
+      expect(isin.deconstruct_keys(nil)[:country_code]).to eq('US')
+    end
+
+    it 'keeps components private' do
+      expect(described_class.private_method_defined?(:components)).to be(true)
+    end
+  end
+
   describe '#== / #eql? / #hash' do
     it 'considers same type with same normalized value equal' do
       expect(SecID::ISIN.new('us5949181045')).to eq(SecID::ISIN.new('US5949181045'))

--- a/spec/support/shared_examples/serialization.rb
+++ b/spec/support/shared_examples/serialization.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# Shared examples for #to_h hash serialization across all identifier types.
+# Shared examples for #to_h serialization and #deconstruct_keys destructuring
+# across all identifier types. Both read the same components hash.
 #
 # @param valid_id [String] a valid identifier
 # @param invalid_id [String] an invalid identifier
@@ -61,6 +62,34 @@ RSpec.shared_examples 'a hashable identifier' do |params|
 
       it 'has type' do
         expect(hash[:type]).to eq(expected_type)
+      end
+    end
+  end
+
+  describe '#deconstruct_keys' do
+    subject(:identifier) { identifier_class.new(valid_id) }
+
+    # Both public readers of `components` are pinned to the same independent literal, which is
+    # what proves they cannot drift. Comparing the two readers to each other would be x == x --
+    # `deconstruct_keys` and `to_h` both call `components`, so it would pass however badly it broke.
+    it 'returns the components hash, equal to to_h[:components]' do
+      expect(identifier.deconstruct_keys(nil)).to eq(expected_components)
+      expect(identifier.to_h[:components]).to eq(expected_components)
+    end
+
+    it 'matches a bare constant pattern' do
+      expect((identifier in ^(identifier_class))).to be(true)
+    end
+
+    it 'matches a hash pattern binding its components' do
+      identifier => { **bound }
+      expect(bound).to eq(expected_components)
+    end
+
+    # AE5: CIK, WKN and Valoren have no sub-fields, so no keyed pattern can match them.
+    if params[:expected_components].empty?
+      it 'matches no keyed pattern' do
+        expect((identifier in { identifier: _ })).to be(false)
       end
     end
   end


### PR DESCRIPTION
## Summary

Identifiers can now be taken apart with Ruby's `case/in`. Previously the only way to read an ISIN's country code or an OCC option's strike was to call the reader, or to route through `#to_h` and index the `:components` sub-hash — pattern matching on a `SecID` object simply never matched a keyed pattern. All fifteen types now bind their parsed fields directly:

```ruby
case SecID.parse(input)
in SecID::ISIN[country_code: 'US', nsin:]        then "US security #{nsin}"
in SecID::OCC[underlying:, type:, strike_mills:] then "#{type} option on #{underlying}"
in nil                                           then 'not a valid identifier'
end
```

One method on `Base` delivers this for every subclass, because they all already funnel their parsed fields through the private `components` hash. `SecID::Match` is a `Data`, so scan results nest into the identifier they wrap without any further work.

## Design decisions

**Validity stays out of the protocol.** `deconstruct_keys` never consults `valid?`. An identifier built from unparseable input binds `nil` for each component rather than failing to match — exactly the shape `#to_h` already reports, and exactly what `MatchData#deconstruct_keys` does for an unmatched group. The validity guard is `SecID.parse` returning `nil`, which an `in nil` branch catches. Gating the match on `valid?` would have made `in SecID::ISIN` mean two different things depending on how the object was constructed.

**No new keys, and no `deconstruct`.** The pattern surface is exactly `:components` — `#to_h`'s envelope keys (`:type`, `:full_id`, `:normalized`, `:valid`) are deliberately absent, so the destructuring contract and the serialization contract can't drift into two different key sets. Array patterns are not supported: the components of an ISIN have no meaningful order, and `deconstruct` would freeze one.

The `keys` argument is ignored. Every type's component hash is small and already materialized, so there is nothing to lazily skip.

## Compatibility

Additive, SemVer MINOR. `components` remains private, `#to_h` and `#as_json` are untouched, and the new RBS signature is declared once on `Base` (a plain method with no backing ivar, so no subclass narrowing is needed).

Two sharp edges worth knowing, both documented in the README:

- `:type` means different things on the two newly-destructurable objects. On a `SecID::Match` it is the registry symbol (`:occ`); on an `OCC` instance it is the OSI option type (`'C'`/`'P'`). So `in SecID::OCC[type: :occ]` never matches.
- CIK, WKN, and Valoren have no sub-fields. They match a bare `in SecID::CIK` but no keyed pattern.

## Test plan

Nine examples in `base_spec.rb` cover the acceptance cases: parsed binding, the `in nil` branch for a bad check digit, destructuring an invalid-check-digit instance, `nil`-binding on unparseable input, nesting inside a `SecID::Match`, the ignored `keys` argument, absence of `deconstruct`, hash freshness per call, and `components` still being private. A shared example runs across all fifteen types for the bare-constant match, the `**rest` binding, and the empty-components case.

The cross-reader assertion in the shared example is pinned to an independent literal rather than comparing `deconstruct_keys` to `to_h[:components]` — both call the same private `components`, so comparing them to each other would reduce to `x == x` and pass however badly it broke. A mutation probe confirmed the literal-pinned form fails under a poisoned `components`.

Full gate green: `rake` (RuboCop + RBS validate + 2199 examples), `rake steep` (strict), `rake steep:coverage` (119 untyped calls, baseline unchanged), `rake rbs:test` (runtime signature conformance), `rake yard:stats` (100% documented), `COVERAGE=1 rspec` (100.0% line coverage).
