### PR TITLE
feat: add suggest for repairing checksum-failing identifiers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,12 +39,14 @@ Metrics/BlockLength:
 
 Metrics/ClassLength:
   Exclude:
+    - 'lib/sec_id.rb'
     - 'lib/sec_id/base.rb'
     - 'lib/sec_id/cfi.rb'
     - 'lib/sec_id/iban.rb'
 
 Metrics/ModuleLength:
   Exclude:
+    - 'lib/sec_id.rb'
     - 'lib/sec_id/concerns/checkable.rb'
 
 Lint/MissingSuper:
@@ -61,5 +63,6 @@ RSpec/SpecFilePathFormat:
   CustomTransform:
     Checkable: concerns/checkable
     Validatable: concerns/validatable
+    Suggestable: concerns/suggestable
     SecIdValidator: active_model
     CFITables: cfi/tables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `suggest` — a checksum-anchored diagnostic-repair verb that turns the checksum from a gatekeeper into a repair engine. For a structurally-valid but checksum-**failing** identifier, `SecID::<Type>.suggest(str)` and `SecID.suggest(str, types:)` enumerate the plausible single-character human errors — visual/OCR homoglyph substitutions (`O`↔`0`, `I`↔`1`, `5`↔`S`, `8`↔`B`, …) and adjacent transpositions — keep only those that re-validate (`valid?` is the oracle, so no false candidate ever escapes), and return them as confidence-ranked `SecID::Suggestion` value objects reporting *what changed* (edit kind, position, from/to characters, confidence tier). Available for all 9 checksum types (ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CEI, DTI, UPI) through one shared `Suggestable` concern. Candidates rank `:high` (homoglyph) then `:medium` (transposition) then a `:checksum` recompute fallback last; there is no `:low` tier (coincidental substitutions are never generated), keeping results small and high-precision. `suggest` never mutates its input and never presents a candidate as an authoritative correction. Non-checksum types (CIK, OCC, WKN, Valoren, CFI, FISN, BIC) have no checksum oracle and are unsupported; `SecID.suggest` silently skips them. Known limitations: the mistyped character must be in the type's charset to be reachable (the vowel-free SEDOL/FIGI/DTI/UPI can't repair an `O`-for-`0`/`I`-for-`1` typo), only a single body error is in scope, and wrong-length input returns `[]`. In a seeded simulation (`benchmark/suggest_precision.rb`), every reachable single-error homoglyph or transposition that yields a checksum-failing identifier is recovered (the correct identifier is always among the returned candidates), the top-ranked body candidate ~89% of the time for homoglyph errors
+
 ## [7.0.0] - 2026-07-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Architecture
 
-This is a Ruby toolkit for securities identifiers (ISIN, CUSIP, CEI, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren, CFI, FISN, BIC, DTI, UPI) — validate, normalize, parse, detect, convert, generate, classify, and calculate checksums. CFI is a full ISO 10962:2021 classifier (`CFI#decode`). Ships an opt-in ActiveModel/Rails validator that adds no runtime dependency to the zero-dependency core.
+This is a Ruby toolkit for securities identifiers (ISIN, CUSIP, CEI, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren, CFI, FISN, BIC, DTI, UPI) — validate, normalize, parse, detect, convert, generate, classify, calculate checksums, and repair. CFI is a full ISO 10962:2021 classifier (`CFI#decode`). Checksum-failing identifiers can be repaired via `suggest` (homoglyph + transposition candidates, confidence-ranked). Ships an opt-in ActiveModel/Rails validator that adds no runtime dependency to the zero-dependency core.
 
 ### Directory Layout
 
@@ -84,6 +84,7 @@ Identifier classes auto-register via `Base.inherited`. Access them through:
 - `SecID.scan(text, types: nil)` — lazy version of `extract`, returns `Enumerator<Match>`
 - `SecID.explain(str, types: nil)` — returns per-type validation results for debugging detection
 - `SecID.generate(key, random: Random.new)` — returns a generated, format-valid instance for a type symbol (raises `ArgumentError` on unknown type); generated values are valid in format only, not real securities
+- `SecID.suggest(str, types: nil)` — returns confidence-ranked `Suggestion` repair candidates for a checksum-failing identifier. Resolves candidate types via the format-only filters (`has_checksum?` + `length_values` + `VALID_CHARS_REGEX`, mirroring detector stages 2–3 — a checksum-failing string never survives `valid?`-based detection), runs each type's `.suggest`, flattens, and ranks cross-type by confidence tier then registration order. `types:` narrows to the given types (non-checksum types are silently dropped — no oracle). The private `suggestable_types` helper does the resolution
 
 ### Detector (`lib/sec_id/detector.rb`)
 
@@ -103,6 +104,10 @@ Lazily instantiated from `SecID.detect`; cache invalidated when new types regist
 `@api private` class that finds identifiers in freeform text. Uses a composite regex with three named groups (FISN, OCC, simple tokens) and cursor-based overlap prevention. Candidates are length-filtered, charset-filtered, and validated, then the most specific match is returned as a `Match` data object (`Data.define(:type, :raw, :range, :identifier)`).
 
 Lazily instantiated from `SecID.scan`/`SecID.extract`; cache invalidated when new types register.
+
+### Suggestion value object (`lib/sec_id/suggestion.rb`)
+
+`Suggestion = Data.define(:type, :identifier, :edit, :position, :from, :to, :confidence)` — the frozen record `suggest` returns, mirroring `Scanner::Match` (flat immutable `Data`, not the hand-rolled CFI value classes). `identifier` is the valid, parsed `SecID::Base` instance (so callers get `.to_s`, `.to_h`, `.country_code` for free); `edit` is `:substitution` / `:transposition` / `:checksum`. Coordinate system: `:substitution` — `position` is the 0-based index, `from`/`to` the single changed characters; `:transposition` — `position` is the left index, `from`/`to` the two-character adjacent substring before/after the swap; `:checksum` — `position` is `nil`, `from`/`to` the old/new check-character string, `confidence` is `nil`. `Data` supplies `==`/`hash`/`to_h`/`deconstruct_keys`; the reopened `class Suggestion` block (not the `Data.define` block, so Steep types `self` as the instance) adds `as_json(*) => to_h`, `to_s => identifier.to_s`, and the runtime-introspectable domain enumerations `EDIT_KINDS` (`%i[substitution transposition checksum]`, rank order) and `CONFIDENCE_LEVELS` (`%i[high medium]`; `:checksum` candidates carry `nil`) — mirroring `Validatable::ERROR_MAP`'s discoverability role so consumers enumerate legal values instead of parsing docs.
 
 ### ActiveModel / Rails Validator (`lib/sec_id/active_model.rb`, `lib/sec_id/railtie.rb`)
 
@@ -181,6 +186,15 @@ Per-type hooks:
 - FIGI resamples its prefix until it is not in `RESTRICTED_PREFIXES`; IBAN generates only numeric-BBAN countries (`NUMERIC_COUNTRY_RULES`); CIK/Valoren use a random integer (not a digit char-fill) to avoid leading-zero bodies
 - CFI samples each attribute position only from the letters `SecID::CFI::Tables` permits for that group (plus `X`; pure-N/A positions yield only `X`, so `K`'s `XXXX` falls out), then applies the `ED` cross-position rule — so every generated code passes strict `valid?`
 
+#### Suggestable (`suggestable.rb`)
+
+The repair engine for checksum-failing identifiers, opt-in `include`d by the 9 checksum types (**not** on `Base` — R9 requires non-checksum types to have no `.suggest`; and **not** folded into `Checkable`, keeping the one-capability-per-concern convention). Adds instance `#suggest` and, via `self.included(base) -> base.extend(ClassMethods)`, class-level `.suggest(str)` (which is `new(str).suggest`).
+
+- Constants: `HOMOGLYPHS` (a frozen `Hash[String, Array[String]]` — the bidirectional homoglyph/OCR confusion table that drives enumeration *and* is the sole substitution candidate space; the recall lever, tuned via `benchmark/suggest_precision.rb`); `RANK` (`{ substitution: 0, transposition: 1, checksum: 2 }`).
+- `#suggest` returns `[]` when the input is already `valid?` (nothing to repair) or not `valid_format?` (unparseable). Otherwise it enumerates, per position, the character's `HOMOGLYPHS` substitutions plus adjacent transpositions, adds the `restore` result (the `:checksum` fallback, guaranteeing the two-character-check case for LEI/IBAN), dedupes, keeps only `self.class.new(candidate).valid?` (the oracle — no false candidate escapes), classifies each survivor, and sorts by `RANK`.
+- Classification is **position-agnostic** (never assumes a trailing checksum — IBAN splices mid-string): `candidate.identifier == identifier` (equal bodies) → `:checksum`; else a single differing index → `:substitution` (`:high`), or an adjacent mutual swap → `:transposition` (`:medium`). No `:low`/coincidental tier is ever generated. `checksum_suggestion` renders `from`/`to` via `checksum` + private `checksum_width` (so a 2-char check reports the full field).
+- Candidate sets stay in the tens per identifier (25/37/52 for a 12/20/22-char id), not hundreds — the human-error net, not a full single-character net.
+
 ### Identifier Classes
 
 Each identifier type (`lib/sec_id/*.rb`) implements:
@@ -190,7 +204,7 @@ Each identifier type (`lib/sec_id/*.rb`) implements:
 - Private `components` method returning a hash of parsed attributes (read by both `#to_h` and `#deconstruct_keys`); classes with no type-specific attributes (CIK, WKN, Valoren) inherit the empty `{}` default
 
 **Classes with checksums** (ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CEI, DTI, UPI):
-- Include `Checkable` concern
+- Include `Checkable` **and** `Suggestable` concerns (the repair engine rides the checksum-as-oracle, so the two are wired together across all 9)
 - Implement `calculate_checksum` with standard-specific algorithm
 - LEI and IBAN override `checksum_width` → `2` (two-character checksum)
 - DTI's and UPI's check "digit" is a `String` (can be a letter), not an `Integer` — the only types where this differs; `Checkable`'s `checksum`/`calculate_checksum` contracts are typed `Integer | String` to admit it

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SecID [![Gem Version](https://badge.fury.io/rb/sec_id.svg)](https://rubygems.org/gems/sec_id) [![CI](https://github.com/svyatov/sec_id/actions/workflows/main.yml/badge.svg)](https://github.com/svyatov/sec_id/actions/workflows/main.yml) [![codecov](https://codecov.io/gh/svyatov/sec_id/graph/badge.svg?token=VV49EMQIIC)](https://codecov.io/gh/svyatov/sec_id) [![Documentation](https://img.shields.io/badge/docs-rubydoc.info-blue.svg)](https://rubydoc.info/gems/sec_id) [![Ruby](https://img.shields.io/badge/ruby-%3E%3D%203.2-CC342D.svg)](https://www.ruby-lang.org) [![Types: RBS](https://img.shields.io/badge/types-RBS-8A2BE2.svg)](https://github.com/svyatov/sec_id/tree/main/sig)
 
-> A Ruby toolkit for securities identifiers — validate, parse, normalize, detect, convert, generate, and classify.
+> A Ruby toolkit for securities identifiers — validate, parse, normalize, detect, convert, generate, classify, and repair.
 
 ## Table of Contents
 
@@ -13,6 +13,7 @@
   - [Structured Validation](#structured-validation) - detailed error codes and messages
   - [Pattern Matching](#pattern-matching) - destructure identifiers with `case/in`
   - [Generating Test Fixtures](#generating-test-fixtures) - produce valid identifiers for tests
+  - [Repairing Typos](#repairing-typos) - suggest corrections for checksum-failing identifiers
   - [ISIN](#isin) - International Securities Identification Number
   - [CUSIP](#cusip) - Committee on Uniform Securities Identification Procedures
   - [CEI](#cei) - CUSIP Entity Identifier
@@ -327,6 +328,41 @@ SecID::LEI.generate(random: Random.new(42)) == SecID::LEI.generate(random: Rando
 > Country codes, FIGI prefixes, OCC expiry dates, and CFI category/group/attribute choices are
 > randomly selected (from the values each standard permits) and do not map to real-world
 > instruments. Use them as test fixtures, not as references to actual securities.
+
+### Repairing Typos
+
+Turn the checksum from a gatekeeper into a repair engine. For a checksum-**failing** identifier, `suggest` enumerates the plausible single-character human errors — visual/OCR homoglyph substitutions (`O`↔`0`, `I`↔`1`, `5`↔`S`, `8`↔`B`, …) and adjacent transpositions — keeps only the edits that re-validate, and returns them as confidence-ranked `SecID::Suggestion` candidates that report *what changed*. Available for all 9 checksum types (ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CEI, DTI, UPI) per class and via the central dispatcher:
+
+```ruby
+# A letter O typed where a 0 belongs — 'US5949181O45' should be 'US5949181045'
+top = SecID::ISIN.suggest('US5949181O45').first
+top.to_s          # => 'US5949181045'  (the corrected identifier)
+top.edit          # => :substitution
+top.position      # => 9
+top.from          # => 'O'
+top.to            # => '0'
+top.confidence    # => :high
+top.identifier    # => #<SecID::ISIN ...>  (parsed and valid — call .country_code, .to_h, etc.)
+
+# Module-level: infers every format-compatible checksum type (like parse / detect)
+SecID.suggest('US5949181O45')                   # => [#<SecID::Suggestion type=:isin ...>, ...]
+SecID.suggest('US5949181O45', types: [:isin])   # => restrict to specific types
+```
+
+Each candidate carries the corrected `identifier` (a parsed, valid instance), the `edit` kind, its `position`, the `from`/`to` characters, and a `confidence` tier. Candidates are ranked by confidence: `:high` homoglyph substitutions first, then `:medium` adjacent transpositions, then the `:checksum` recompute (body assumed correct, wrong check character) last as a fallback hypothesis. **There is no `:low` tier** — coincidental substitutions that merely satisfy the checksum are never generated, keeping the result small and high-precision.
+
+> **`suggest` returns candidates, never authoritative corrections, and never mutates its input.**
+> Every returned candidate fully re-validates (`valid?` is the oracle), so no false candidate escapes —
+> but the `confidence` tier is how *you* decide what to trust. This matters for financial identifiers.
+
+Notes and limitations:
+
+- **Never empty for structurally-valid input** — a parseable but checksum-failing identifier always yields at least the `:checksum` fallback. Only wrong-length or illegal-charset input (which fails the format gate) returns `[]`.
+- **Vowel-free reachability** — SEDOL, FIGI, DTI, and UPI exclude vowels from their charset, so an `O`-for-`0` or `I`-for-`1` typo is unparseable and therefore unrepairable (it fails the format gate before enumeration). The mistyped character must be *in* the type's charset to be reachable.
+- **Single body error only** — two or more wrong body characters, or a dropped/doubled character (insertion/deletion), are out of scope; such input returns only the `:checksum` fallback, never additional body candidates.
+- **Non-checksum types are unsupported** — CIK, OCC, WKN, Valoren, CFI, FISN, and BIC have no checksum oracle, so they have no `suggest`; `SecID.suggest` silently skips them.
+
+**Precision** (simulated over 1,000 seeded samples per checksum type — see [`benchmark/suggest_precision.rb`](benchmark/suggest_precision.rb)): every reachable, single-error homoglyph or transposition that yields a checksum-failing identifier is recovered — the correct identifier is **always** among the returned candidates (100%), and is the top-ranked body candidate ~89% of the time for homoglyph errors. In-charset homoglyph reachability averages ~96% (100% for the letter-permitting types, lower for the four vowel-free ones).
 
 ### ISIN
 

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -29,7 +29,9 @@ CASES = {
   'SecID.valid? (unknown -> detector)' => -> { SecID.valid?(VALID_ISIN) },
   'SecID.detect' => -> { SecID.detect(VALID_ISIN) },
   'SecID.parse' => -> { SecID.parse(VALID_ISIN) },
-  'SecID.extract (paragraph)' => -> { SecID.extract(TEXT) }
+  'SecID.extract (paragraph)' => -> { SecID.extract(TEXT) },
+  'ISIN.suggest (repair)' => -> { SecID::ISIN.suggest(BAD_CD_ISIN) },
+  'SecID.suggest (module)' => -> { SecID.suggest(BAD_CD_ISIN) }
 }.freeze
 
 puts "Ruby #{RUBY_VERSION}\n\n== Throughput =="

--- a/benchmark/suggest_precision.rb
+++ b/benchmark/suggest_precision.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+# Precision simulation for SecID#suggest (the human-error net).
+# Run with: ruby -Ilib benchmark/suggest_precision.rb
+#
+# For each checksum type it draws valid identifiers via `.generate`, injects a single
+# known error — a homoglyph substitution and, separately, an adjacent transposition —
+# at random BODY positions, runs `suggest`, and measures three distinct axes:
+#
+#   - reachability: fraction of injected homoglyph typos whose mistyped character stays
+#     in the type's charset. An out-of-charset typo (O-for-0, I-for-1 in the vowel-free
+#     SEDOL/FIGI/DTI/UPI) is unparseable, so it can never be repaired — expected < 100%
+#     only for those four types.
+#   - repairable: fraction of (reachable) typos that yield a format-valid, checksum-FAILING
+#     input — the engine's actual domain. Below 100% because some typos break structural
+#     format instead (a letter in IBAN's numeric BBAN, a digit in a country code) or stay
+#     coincidentally valid (the checksum blind spot).
+#   - correction: over repairable typos, the fraction where the original identifier is
+#     recovered — present among the candidates, and separately, the TOP-ranked body
+#     candidate. Recovery is ~100% by construction (the reverting edit is always
+#     enumerated and always re-validates); top-rank dips when a coincidental homoglyph
+#     out-ranks the true fix.
+#
+# Analysis harness only — not shipped in the gem. The RNG is seeded for reproducibility.
+
+require 'sec_id'
+
+SEED = 20_260_714
+SAMPLES = 1_000
+TYPES = %i[isin cusip sedol figi lei iban cei dti upi].freeze
+HOMOGLYPHS = SecID::Suggestable::HOMOGLYPHS
+HEADERS = %w[type h-reach h-repair h-found h-top t-found t-top set-avg set-max].freeze
+
+Trial = Struct.new(:reachable, :repairable, :corrected, :top_body, :set_size)
+
+# Body positions of a valid identifier — the characters that are not the check field.
+# Only IBAN carries its two check digits mid-string (positions 2-3); the rest trail.
+def body_positions(klass, valid)
+  return (0...valid.length).to_a - [2, 3] if klass == SecID::IBAN
+
+  (0...klass.new(valid).identifier.length).to_a
+end
+
+def measure(klass, valid, typo, reachable)
+  return Trial.new(false, false, false, false, 0) unless reachable
+
+  instance = klass.new(typo)
+  return Trial.new(true, false, false, false, 0) unless instance.send(:valid_format?) && !instance.valid?
+
+  outcome(klass.suggest(typo), valid)
+end
+
+def outcome(suggestions, valid)
+  body = suggestions.reject { |s| s.edit == :checksum }
+  Trial.new(true, true, suggestions.any? { |s| s.to_s == valid }, body.first&.to_s == valid, suggestions.size)
+end
+
+# Inject a homoglyph typo: pick a body char with a homoglyph partner, type the partner.
+def homoglyph_trial(klass, valid, rng)
+  positions = body_positions(klass, valid).select { |i| HOMOGLYPHS.key?(valid[i]) }
+  return if positions.empty?
+
+  index = positions.sample(random: rng)
+  typo_char = HOMOGLYPHS.fetch(valid[index]).sample(random: rng)
+  typo = valid.dup.tap { |s| s[index] = typo_char }
+  measure(klass, valid, typo, typo_char.match?(klass::VALID_CHARS_REGEX))
+end
+
+# Inject an adjacent transposition of two differing body characters (always in-charset).
+def transposition_trial(klass, valid, rng)
+  pairs = adjacent_body_pairs(klass, valid)
+  return if pairs.empty?
+
+  left, right = pairs.sample(random: rng)
+  typo = valid.dup.tap { |s| s[left], s[right] = s[right], s[left] }
+  measure(klass, valid, typo, true)
+end
+
+def adjacent_body_pairs(klass, valid)
+  body_positions(klass, valid).each_cons(2).select { |a, b| b == a + 1 && valid[a] != valid[b] }
+end
+
+def collect(klass, &trial)
+  rng = Random.new(SEED)
+  Array.new(SAMPLES) { trial.call(klass, klass.generate(random: rng).to_s, rng) }.compact
+end
+
+def rate(trials, &)
+  return 0.0 if trials.empty?
+
+  trials.count(&).fdiv(trials.size)
+end
+
+def avg(values)
+  values.empty? ? 0.0 : values.sum.fdiv(values.size)
+end
+
+# Flat metric aggregation — inherently many trivial rate() calls.
+def metrics(key, homoglyph, transposition)
+  reachable = homoglyph.select(&:reachable)
+  h_ok = reachable.select(&:repairable)
+  t_ok = transposition.select(&:repairable)
+  sizes = (h_ok + t_ok).map(&:set_size)
+  {
+    key: key, reachability: rate(homoglyph, &:reachable), h_repairable: rate(reachable, &:repairable),
+    h_found: rate(h_ok, &:corrected), h_top: rate(h_ok, &:top_body),
+    t_found: rate(t_ok, &:corrected), t_top: rate(t_ok, &:top_body),
+    avg_size: avg(sizes), max_size: sizes.max || 0
+  }
+end
+
+def summarize(key)
+  klass = SecID[key]
+  metrics(key, collect(klass, &method(:homoglyph_trial)), collect(klass, &method(:transposition_trial)))
+end
+
+def pct(value)
+  format('%<value>5.1f%%', value: value * 100)
+end
+
+def render(cells)
+  head, *rest = cells
+  [head.to_s.ljust(7), *rest.map { |cell| cell.to_s.rjust(9) }].join
+end
+
+def data_row(row)
+  render([
+           row[:key], pct(row[:reachability]), pct(row[:h_repairable]), pct(row[:h_found]), pct(row[:h_top]),
+           pct(row[:t_found]), pct(row[:t_top]), format('%<n>.1f', n: row[:avg_size]), row[:max_size],
+         ])
+end
+
+def mean(rows, key)
+  rows.sum { |row| row[key] }.fdiv(rows.size)
+end
+
+rows = TYPES.map { |key| summarize(key) }
+divider = '-' * render(HEADERS).length
+
+puts "SecID#suggest precision simulation — #{SAMPLES} samples/type, seed #{SEED}, Ruby #{RUBY_VERSION}"
+puts '(homoglyph = h, transposition = t; found/top are over repairable typos)'
+puts
+puts render(HEADERS)
+puts divider
+rows.each { |row| puts data_row(row) }
+puts divider
+puts
+puts 'Headline (mean across the 9 checksum types):'
+puts "  in-charset homoglyph reachability:      #{pct(mean(rows, :reachability))}"
+puts "  correction rate (repairable homoglyph): #{pct(mean(rows,
+                                                           :h_found))}  (top-ranked body: #{pct(mean(rows, :h_top))})"
+puts "  correction rate (repairable transp.):   #{pct(mean(rows,
+                                                           :t_found))}  (top-ranked body: #{pct(mean(rows, :t_top))})"

--- a/lib/sec_id.rb
+++ b/lib/sec_id.rb
@@ -143,7 +143,39 @@ module SecID
       self[key].generate(random: random)
     end
 
+    # Returns confidence-ranked repair candidates for a checksum-failing identifier,
+    # inferred across all format-compatible checksum types (or the given `types:`).
+    #
+    # @note Repair is only defined for checksum types; non-checksum types have no
+    #   oracle and are silently skipped.
+    #
+    # @param str [String, nil] the identifier string to repair
+    # @param types [Array<Symbol>, nil] restrict to specific types (non-checksum types are ignored)
+    # @return [Array<Suggestion>] cross-type ranked candidates, each carrying its `type`;
+    #   empty when no format-compatible checksum type matches
+    # @raise [ArgumentError] if any key in types is unknown
+    def suggest(str, types: nil)
+      input = str.to_s.strip.upcase
+      suggestable_types(input, types)
+        .flat_map { |klass| klass.suggest(input) }
+        .sort_by { |suggestion| [Suggestable::RANK.fetch(suggestion.edit), self[suggestion.type].detection_priority.last] }
+    end
+
     private
+
+    # Resolves the checksum types eligible to repair `input` (KTD4): the given `types:`
+    # narrowed to checksum types, or every checksum type whose length and charset admit it.
+    #
+    # @param input [String] the normalized (stripped, upcased) input
+    # @param types [Array<Symbol>, nil]
+    # @return [Array<Class>]
+    def suggestable_types(input, types)
+      return types.map { |key| self[key] }.select(&:has_checksum?) if types
+
+      identifier_list.select do |klass|
+        klass.has_checksum? && klass.length_values.include?(input.length) && input.match?(klass::VALID_CHARS_REGEX)
+      end
+    end
 
     # @return [void]
     def register_identifier(klass)
@@ -206,7 +238,9 @@ require 'sec_id/concerns/normalizable'
 require 'sec_id/concerns/validatable'
 require 'sec_id/concerns/checkable'
 require 'sec_id/concerns/generatable'
+require 'sec_id/concerns/suggestable'
 require 'sec_id/base'
+require 'sec_id/suggestion'
 require 'sec_id/detector'
 require 'sec_id/scanner'
 require 'sec_id/isin'

--- a/lib/sec_id/cei.rb
+++ b/lib/sec_id/cei.rb
@@ -12,6 +12,7 @@ module SecID
   #   SecID::CEI.valid?('A0BCDEFGH1')  #=> true
   class CEI < Base
     include Checkable
+    include Suggestable
 
     # Human-readable name of the standard.
     FULL_NAME = 'CUSIP Entity Identifier'

--- a/lib/sec_id/concerns/suggestable.rb
+++ b/lib/sec_id/concerns/suggestable.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+module SecID
+  # Repair engine for checksum-failing identifiers: enumerates plausible single-character
+  # edits (homoglyph/OCR substitutions and adjacent transpositions), keeps only those that
+  # re-validate, and returns them as confidence-ranked {Suggestion} objects.
+  #
+  # Included by the 9 checksum types. The candidate space is the human-error net —
+  # {HOMOGLYPHS} plus adjacent transpositions — never a full coincidental net. `valid?`
+  # is the oracle, so no false candidate ever escapes; the {HOMOGLYPHS} table bounds recall.
+  #
+  # @see SecID::Suggestion
+  #
+  # @example
+  #   SecID::ISIN.suggest('US5949181O45')
+  #   #=> [#<SecID::Suggestion edit=:substitution ...>, #<SecID::Suggestion edit=:checksum ...>]
+  module Suggestable
+    # Homoglyph / OCR confusion table (KTD5 seed): each character maps to the characters
+    # it is commonly mistyped as or misread from. A bidirectional expansion of the seed
+    # pairs {0/O, 0/Q, 0/D, 1/I, 1/L, I/L, 2/Z, 5/S, 6/G, 8/B}. Membership bounds recall —
+    # widen it (see benchmark/suggest_precision.rb) to raise it.
+    HOMOGLYPHS = {
+      '0' => %w[O Q D], 'O' => %w[0], 'Q' => %w[0], 'D' => %w[0],
+      '1' => %w[I L], 'I' => %w[1 L], 'L' => %w[1 I],
+      '2' => %w[Z], 'Z' => %w[2], '5' => %w[S], 'S' => %w[5],
+      '6' => %w[G], 'G' => %w[6], '8' => %w[B], 'B' => %w[8]
+    }.freeze
+
+    # Rank weight per edit kind: body substitutions first, then adjacent transpositions,
+    # then the checksum-recompute fallback last (R6/R7).
+    RANK = { substitution: 0, transposition: 1, checksum: 2 }.freeze
+
+    # @api private
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    # Class methods added when Suggestable is included.
+    module ClassMethods
+      # Returns confidence-ranked repair candidates for a checksum-failing identifier.
+      #
+      # @param str [String] the identifier string to repair
+      # @return [Array<Suggestion>] ranked candidates; empty when `str` is already valid
+      #   or fails the type's format (wrong length or charset)
+      def suggest(str)
+        new(str).suggest
+      end
+    end
+
+    # Enumerates plausible edits and returns the re-validating ones, confidence-ranked.
+    #
+    # @return [Array<Suggestion>] ranked candidates; empty when already valid or unparseable
+    def suggest
+      return [] if valid?
+      return [] unless valid_format?
+
+      surviving = candidate_strings.uniq.map { |candidate| self.class.new(candidate) }.select(&:valid?)
+      surviving.filter_map { |candidate| classify(candidate) }.sort_by { |suggestion| RANK.fetch(suggestion.edit) }
+    end
+
+    private
+
+    # Homoglyph substitutions + adjacent transpositions + the checksum recompute (R4, R6).
+    #
+    # @return [Array<String>] candidate identifier strings (unfiltered, may include duplicates)
+    def candidate_strings
+      homoglyph_candidates + transposition_candidates + [restore]
+    end
+
+    # @return [Array<String>]
+    def homoglyph_candidates
+      full_id.each_char.with_index.flat_map do |char, index|
+        Array(HOMOGLYPHS[char]).map { |replacement| replace_at(full_id, index, replacement) }
+      end
+    end
+
+    # @return [Array<String>]
+    def transposition_candidates
+      (0...(full_id.length - 1)).filter_map do |index|
+        swap_at(full_id, index) unless full_id[index] == full_id[index + 1]
+      end
+    end
+
+    # @param str [String]
+    # @param index [Integer]
+    # @param char [String] the replacement character
+    # @return [String]
+    def replace_at(str, index, char)
+      str.dup.tap { |copy| copy[index] = char }
+    end
+
+    # @param str [String]
+    # @param index [Integer] left index of the adjacent pair to swap
+    # @return [String]
+    def swap_at(str, index)
+      str.dup.tap { |copy| copy[index], copy[index + 1] = copy[index + 1], copy[index] }
+    end
+
+    # Tags a surviving candidate by comparing bodies then diffing the strings (KTD3):
+    # equal bodies mean only the check characters changed.
+    #
+    # @param candidate [SecID::Base] a re-validated candidate instance
+    # @return [Suggestion, nil] nil when the diff is neither a single substitution nor an adjacent swap
+    def classify(candidate)
+      return checksum_suggestion(candidate) if candidate.identifier == identifier
+
+      changed = changed_indices(candidate)
+      case changed.size
+      when 1 then substitution_suggestion(candidate, changed.first.to_i)
+      when 2 then transposition_suggestion(candidate, changed)
+      end
+    end
+
+    # @param candidate [SecID::Base]
+    # @return [Array<Integer>] indices where the candidate's string differs from the input's
+    def changed_indices(candidate)
+      other = candidate.full_id
+      (0...full_id.length).reject { |index| full_id[index] == other[index] }
+    end
+
+    # @param candidate [SecID::Base]
+    # @param index [Integer]
+    # @return [Suggestion]
+    def substitution_suggestion(candidate, index)
+      Suggestion.new(
+        type: self.class.type_key, identifier: candidate, edit: :substitution,
+        position: index, from: full_id[index].to_s, to: candidate.full_id[index].to_s, confidence: :high
+      )
+    end
+
+    # @param candidate [SecID::Base]
+    # @param indices [Array<Integer>] the two differing indices
+    # @return [Suggestion, nil] nil unless the two indices are an adjacent, mutual swap
+    def transposition_suggestion(candidate, indices)
+      left = indices.min.to_i
+      right = indices.max.to_i
+      return unless right == left + 1 && swap?(candidate, left, right)
+
+      Suggestion.new(
+        type: self.class.type_key, identifier: candidate, edit: :transposition,
+        position: left, from: full_id[left, 2].to_s, to: candidate.full_id[left, 2].to_s, confidence: :medium
+      )
+    end
+
+    # @param candidate [SecID::Base]
+    # @param left [Integer]
+    # @param right [Integer]
+    # @return [Boolean] true when the two positions are a mutual swap of the input's characters
+    def swap?(candidate, left, right)
+      full_id[left] == candidate.full_id[right] && full_id[right] == candidate.full_id[left]
+    end
+
+    # @param candidate [SecID::Base]
+    # @return [Suggestion]
+    def checksum_suggestion(candidate)
+      Suggestion.new(
+        type: self.class.type_key, identifier: candidate, edit: :checksum, position: nil,
+        from: rendered_checksum(checksum), to: rendered_checksum(candidate.checksum), confidence: nil
+      )
+    end
+
+    # @param value [Integer, String, nil] a checksum value
+    # @return [String] the check-character string, zero-padded to the checksum width ('' when absent)
+    def rendered_checksum(value)
+      value.nil? ? '' : value.to_s.rjust(checksum_width, '0')
+    end
+  end
+end

--- a/lib/sec_id/cusip.rb
+++ b/lib/sec_id/cusip.rb
@@ -16,6 +16,7 @@ module SecID
   #   cusip.to_isin('US')  #=> #<SecID::ISIN>
   class CUSIP < Base
     include Checkable
+    include Suggestable
 
     # Human-readable name of the standard.
     FULL_NAME = 'Committee on Uniform Securities Identification Procedures'

--- a/lib/sec_id/dti.rb
+++ b/lib/sec_id/dti.rb
@@ -17,6 +17,7 @@ module SecID
   #   SecID::DTI.restore('X9J9K872')  #=> 'X9J9K872S'
   class DTI < Base
     include Checkable
+    include Suggestable
 
     # Human-readable name of the standard.
     FULL_NAME = 'Digital Token Identifier'

--- a/lib/sec_id/figi.rb
+++ b/lib/sec_id/figi.rb
@@ -16,6 +16,7 @@ module SecID
   #   SecID::FIGI.restore!('BBG000BLNQ1')  #=> #<SecID::FIGI>
   class FIGI < Base
     include Checkable
+    include Suggestable
 
     # Human-readable name of the standard.
     FULL_NAME = 'Financial Instrument Global Identifier'

--- a/lib/sec_id/iban.rb
+++ b/lib/sec_id/iban.rb
@@ -19,6 +19,7 @@ module SecID
   #   SecID::IBAN.restore!('DE00370400440532013000')  #=> #<SecID::IBAN>
   class IBAN < Base
     include Checkable
+    include Suggestable
 
     # Human-readable name of the standard.
     FULL_NAME = 'International Bank Account Number'

--- a/lib/sec_id/isin.rb
+++ b/lib/sec_id/isin.rb
@@ -15,6 +15,7 @@ module SecID
   #   SecID::ISIN.restore!('US594918104')  #=> #<SecID::ISIN>
   class ISIN < Base
     include Checkable
+    include Suggestable
 
     # Human-readable name of the standard.
     FULL_NAME = 'International Securities Identification Number'

--- a/lib/sec_id/lei.rb
+++ b/lib/sec_id/lei.rb
@@ -16,6 +16,7 @@ module SecID
   #   SecID::LEI.checksum('529900T8BM49AURSDO')  #=> 55
   class LEI < Base
     include Checkable
+    include Suggestable
 
     # Human-readable name of the standard.
     FULL_NAME = 'Legal Entity Identifier'

--- a/lib/sec_id/sedol.rb
+++ b/lib/sec_id/sedol.rb
@@ -16,6 +16,7 @@ module SecID
   #   SecID::SEDOL.checksum('B19GKT')  #=> 4
   class SEDOL < Base
     include Checkable
+    include Suggestable
 
     # Human-readable name of the standard.
     FULL_NAME = 'Stock Exchange Daily Official List'

--- a/lib/sec_id/suggestion.rb
+++ b/lib/sec_id/suggestion.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module SecID
+  # Immutable value object representing one repair candidate returned by `suggest`.
+  #
+  # Carries the corrected, re-validated identifier plus the what-changed diff (edit
+  # kind, position, from/to characters) and a confidence tier — the honest surface
+  # that keeps a candidate from reading as an authoritative correction.
+  #
+  # Coordinate system by edit kind:
+  # - `:substitution` — `position` is the 0-based index of the changed character;
+  #   `from`/`to` are the single characters before/after.
+  # - `:transposition` — `position` is the left index of the swapped pair;
+  #   `from`/`to` are the two-character adjacent substring before/after the swap.
+  # - `:checksum` — `position` is `nil`; `from`/`to` are the old/new check-character
+  #   string. `confidence` is `nil` (it is the fallback hypothesis, ranked last).
+  #
+  # @!attribute [r] type
+  #   @return [Symbol] the identifier type key (e.g. :isin)
+  # @!attribute [r] identifier
+  #   @return [SecID::Base] the valid, parsed corrected identifier
+  # @!attribute [r] edit
+  #   @return [Symbol] :substitution, :transposition, or :checksum
+  # @!attribute [r] position
+  #   @return [Integer, nil] the edit position (nil for :checksum)
+  # @!attribute [r] from
+  #   @return [String] the original character(s)
+  # @!attribute [r] to
+  #   @return [String] the replacement character(s)
+  # @!attribute [r] confidence
+  #   @return [Symbol, nil] :high (homoglyph), :medium (transposition), or nil (:checksum)
+  #
+  # @example
+  #   suggestion = SecID::ISIN.suggest('US5949181O45').first
+  #   suggestion.to_s          #=> 'US5949181045'
+  #   suggestion.edit          #=> :substitution
+  #   suggestion.confidence    #=> :high
+  Suggestion = Data.define(:type, :identifier, :edit, :position, :from, :to, :confidence)
+
+  # Reopened to add the domain enumerations and serialization helpers per the repo
+  # convention (see {Base#as_json}).
+  class Suggestion
+    # The edit kinds `edit` can take, in rank order (see {Suggestable::RANK}).
+    EDIT_KINDS = %i[substitution transposition checksum].freeze
+
+    # The non-nil confidence tiers `confidence` can take; `:checksum` candidates carry `nil`.
+    CONFIDENCE_LEVELS = %i[high medium].freeze
+
+    # @return [Hash] the symbol-keyed field hash (JSON-compatible)
+    def as_json(*)
+      to_h
+    end
+
+    # @return [String] the corrected identifier string
+    def to_s
+      identifier.to_s
+    end
+  end
+end

--- a/lib/sec_id/upi.rb
+++ b/lib/sec_id/upi.rb
@@ -18,6 +18,7 @@ module SecID
   #   SecID::UPI.restore('QZRBG6ZTKS4')  #=> 'QZRBG6ZTKS42'
   class UPI < Base
     include Checkable
+    include Suggestable
 
     # Human-readable name of the standard.
     FULL_NAME = 'Unique Product Identifier'

--- a/sec_id.gemspec
+++ b/sec_id.gemspec
@@ -11,9 +11,10 @@ Gem::Specification.new do |spec|
   spec.email         = ['leonid@svyatov.ru']
 
   spec.summary       = 'A Ruby toolkit for securities identifiers — validate, parse, normalize, detect, convert, ' \
-                       'generate, and classify.'
-  spec.description   = 'Validate, normalize, parse, convert, generate, and classify securities identifiers. ' \
-                       'Auto-detect identifier type from any string. Calculate and restore checksums. Generate ' \
+                       'generate, classify, and repair.'
+  spec.description   = 'Validate, normalize, parse, convert, generate, classify, and repair securities identifiers. ' \
+                       'Auto-detect identifier type from any string. Calculate and restore checksums. Suggest ' \
+                       'confidence-ranked corrections for fat-fingered or OCR-mangled identifiers. Generate ' \
                        'format-valid identifiers as test fixtures. Decode CFI codes to full ISO 10962:2021 ' \
                        'classifications. Includes an opt-in ActiveModel/Rails validator that adds no runtime ' \
                        'dependency. Supports ISIN, CUSIP, CEI, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren, ' \

--- a/sig/sec_id.rbs
+++ b/sig/sec_id.rbs
@@ -38,9 +38,11 @@ module SecID
   # against the `:first`/`:raise` arm's `Base?` and fail. Widening here keeps `result` untyped.
   def self.parse!: (SecID::input str, ?types: Array[Symbol]?, ?on_ambiguous: Symbol) -> (Base | Array[Base])
   def self.generate: (Symbol key, ?random: Random) -> Base
+  def self.suggest: (SecID::input str, ?types: Array[Symbol]?) -> Array[Suggestion]
 
   # Singleton-method privacy must be declared inline (`private def self.…`); a bare
   # `private` section only affects instance methods, leaving these public.
+  private def self.suggestable_types: (String input, Array[Symbol]? types) -> Array[singleton(Base)]
   private def self.register_identifier: (singleton(Base) klass) -> void
   private def self.parse_any: (SecID::input str) -> Base?
   private def self.parse_from: (SecID::input str, Array[Symbol] types) -> Base?

--- a/sig/sec_id/base.rbs
+++ b/sig/sec_id/base.rbs
@@ -43,6 +43,9 @@ module SecID
     def self.length_specificity: () -> (Integer | Float | nil)
     def self.example: () -> String
     def self.has_checksum?: () -> bool
+    # Only Suggestable (checksum) types implement `.suggest`; declared here so the
+    # module-level `SecID.suggest` can call it on any registered class object.
+    def self.suggest: (SecID::input str) -> Array[Suggestion]
 
     # @deprecated v7 bridge alias for `has_checksum?`; removed in v8.
     def self.has_check_digit?: () -> bool
@@ -58,12 +61,15 @@ module SecID
     def as_json: (*untyped) -> Hash[Symbol, untyped]
     def deconstruct_keys: (::Array[Symbol]? _keys) -> Hash[Symbol, untyped]
 
-    # Checksum surface. Only the types that `include Checkable` implement these
-    # (they raise/NoMethodError otherwise); declared on Base so `Generatable#generate`
-    # and `Checkable::ClassMethods` type-check without narrowing on `has_checksum?`.
+    # Checksum / repair surface. Only the types that `include Checkable` /
+    # `include Suggestable` implement these (they raise/NoMethodError otherwise);
+    # declared on Base so `Generatable#generate`, `Checkable::ClassMethods`, and the
+    # Base-self-typed `Suggestable` body type-check without narrowing on `has_checksum?`.
     def restore: () -> String
     def restore!: () -> self
     def calculate_checksum: () -> (Integer | String)
+    attr_reader checksum: (Integer | String)?
+    def suggest: () -> Array[Suggestion]
 
     def comparison_id: () -> String
 

--- a/sig/sec_id/concerns/checkable.rbs
+++ b/sig/sec_id/concerns/checkable.rbs
@@ -6,7 +6,8 @@ module SecID
 
     def self.included: (Module base) -> void
 
-    attr_reader checksum: (Integer | String)?
+    # `attr_reader checksum` is declared on Base (the repair surface) to keep the
+    # Base-self-typed Suggestable body type-checking; not redeclared here.
 
     # Class methods added when Checkable is included.
     module ClassMethods : SecID::_IdentifierClass

--- a/sig/sec_id/concerns/suggestable.rbs
+++ b/sig/sec_id/concerns/suggestable.rbs
@@ -1,0 +1,32 @@
+module SecID
+  # Repair engine for checksum-failing identifiers: enumerates plausible edits and
+  # returns the re-validating ones as confidence-ranked Suggestion objects.
+  module Suggestable : SecID::Base
+    HOMOGLYPHS: Hash[String, Array[String]]
+    RANK: Hash[Symbol, Integer]
+
+    def self.included: (Module base) -> void
+
+    # Class methods added when Suggestable is included.
+    module ClassMethods : SecID::_IdentifierClass
+      def suggest: (SecID::input str) -> Array[Suggestion]
+    end
+
+    def suggest: () -> Array[Suggestion]
+
+    private
+
+    def candidate_strings: () -> Array[String]
+    def homoglyph_candidates: () -> Array[String]
+    def transposition_candidates: () -> Array[String]
+    def replace_at: (String str, Integer index, String char) -> String
+    def swap_at: (String str, Integer index) -> String
+    def classify: (Base candidate) -> Suggestion?
+    def changed_indices: (Base candidate) -> Array[Integer]
+    def substitution_suggestion: (Base candidate, Integer index) -> Suggestion
+    def transposition_suggestion: (Base candidate, Array[Integer] indices) -> Suggestion?
+    def swap?: (Base candidate, Integer left, Integer right) -> bool
+    def checksum_suggestion: (Base candidate) -> Suggestion
+    def rendered_checksum: ((Integer | String)? value) -> String
+  end
+end

--- a/sig/sec_id/suggestion.rbs
+++ b/sig/sec_id/suggestion.rbs
@@ -1,0 +1,23 @@
+module SecID
+  # Immutable value object representing one repair candidate returned by `suggest`.
+  class Suggestion < Data
+    EDIT_KINDS: Array[Symbol]
+    CONFIDENCE_LEVELS: Array[Symbol]
+
+    attr_reader type: Symbol
+    attr_reader identifier: Base
+    attr_reader edit: Symbol
+    attr_reader position: Integer?
+    attr_reader from: String
+    attr_reader to: String
+    attr_reader confidence: Symbol?
+
+    def self.new: (type: Symbol, identifier: Base, edit: Symbol, position: Integer?, from: String, to: String, confidence: Symbol?) -> instance
+                | (Symbol type, Base identifier, Symbol edit, Integer? position, String from, String to, Symbol? confidence) -> instance
+    def self.[]: (type: Symbol, identifier: Base, edit: Symbol, position: Integer?, from: String, to: String, confidence: Symbol?) -> instance
+               | (Symbol type, Base identifier, Symbol edit, Integer? position, String from, String to, Symbol? confidence) -> instance
+
+    def as_json: (*untyped) -> Hash[Symbol, untyped]
+    def to_s: () -> String
+  end
+end

--- a/spec/sec_id/concerns/suggestable_spec.rb
+++ b/spec/sec_id/concerns/suggestable_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SecID::Suggestable do
+  describe 'AE1: homoglyph fix plus checksum fallback' do
+    subject(:suggestions) { SecID::ISIN.suggest('US5949181O45') }
+
+    it 'returns the O->0 homoglyph substitution as a :high candidate' do
+      fix = suggestions.find { |s| s.edit == :substitution && s.position == 9 }
+      expect(fix).to have_attributes(from: 'O', to: '0', confidence: :high, to_s: 'US5949181045')
+    end
+
+    it 'ranks the always-present :checksum recompute candidate last' do
+      expect(suggestions.last.edit).to eq(:checksum)
+    end
+  end
+
+  describe 'AE3: check-character typo yields a :checksum candidate ranked last' do
+    subject(:suggestions) { SecID::ISIN.suggest('US5949181046') } # body correct, check 6 should be 5
+
+    it 'includes a :checksum candidate with the recomputed check character' do
+      checksum = suggestions.find { |s| s.edit == :checksum }
+      expect(checksum).to have_attributes(position: nil, from: '6', to: '5', confidence: nil, to_s: 'US5949181045')
+    end
+
+    it 'ranks the :checksum candidate last' do
+      expect(suggestions.last.edit).to eq(:checksum)
+    end
+  end
+
+  describe 'AE2: multiple plausible edits ranked :high, :medium, then :checksum' do
+    subject(:suggestions) { SecID::ISIN.suggest('US5499181045') } # 9<->4 transposed at index 3
+
+    it 'returns substitutions before transpositions before the checksum fallback' do
+      grouped = suggestions.map(&:edit).chunk_while { |a, b| a == b }.map(&:first)
+      expect(grouped).to eq(%i[substitution transposition checksum])
+    end
+
+    it 'includes the reverting adjacent transposition tagged :medium' do
+      transposition = suggestions.find { |s| s.edit == :transposition }
+      expect(transposition).to have_attributes(position: 3, from: '49', to: '94', confidence: :medium)
+    end
+
+    it 'places every :high candidate before every :medium candidate' do
+      last_high = suggestions.rindex { |s| s.confidence == :high }
+      first_medium = suggestions.index { |s| s.confidence == :medium }
+      expect(last_high).to be < first_medium
+    end
+  end
+
+  describe 'AE4: no structural parse returns an empty Array' do
+    it 'returns [] for wrong-length input' do
+      expect(SecID::ISIN.suggest('US594')).to eq([])
+    end
+
+    it 'returns [] for illegal-charset input' do
+      expect(SecID::ISIN.suggest('US5949181@45')).to eq([])
+    end
+  end
+
+  describe 'already-valid input' do
+    it 'returns [] (nothing to repair)' do
+      expect(SecID::ISIN.suggest('US5949181045')).to eq([])
+    end
+  end
+
+  describe 'missing checksum character (nil check field)' do
+    # Input typed without its check character: valid_format? passes (the checksum is
+    # optional for the length check) but valid? fails, so the bodies are equal and the
+    # :checksum candidate renders an empty `from` (there was no check character to correct).
+    it 'yields a :checksum candidate with an empty from' do
+      checksum = SecID::ISIN.suggest('US594918104').find { |s| s.edit == :checksum }
+      expect(checksum).to have_attributes(position: nil, from: '', to: '5', to_s: 'US5949181045')
+    end
+  end
+
+  describe 'coincidental exclusion (no :low tier)' do
+    # Corrupt 4->7 (not a homoglyph pair) so the only body fix is the coincidental
+    # revert; it must NOT be suggested — only the :checksum fallback survives.
+    subject(:suggestions) { SecID::CUSIP.suggest('7P3JNSEN6') } # valid is 4P3JNSEN6
+
+    it 'never returns the non-homoglyph revert substitution' do
+      revert = suggestions.find { |s| s.edit == :substitution && s.position.zero? && s.to == '4' }
+      expect(revert).to be_nil
+    end
+
+    it 'still returns the :checksum fallback (never empty for structurally-valid input)' do
+      expect(suggestions.map(&:edit)).to include(:checksum)
+    end
+  end
+
+  describe 'transposition tagging' do
+    it 'tags an adjacent-swap fix :transposition / :medium' do
+      transposition = SecID::ISIN.suggest('US5499181045').find { |s| s.edit == :transposition }
+      expect(transposition.confidence).to eq(:medium)
+    end
+  end
+
+  describe 'LEI (two-character checksum)' do
+    # A single substitution cannot reach both check digits; restore supplies the candidate.
+    it 'repairs a wrong two-digit check via the :checksum candidate' do
+      lei = SecID::LEI.generate(random: Random.new(1)).to_s
+      wrong = lei[18, 2] == '00' ? '11' : '00'
+      suggestions = SecID::LEI.suggest("#{lei[0, 18]}#{wrong}")
+      checksum = suggestions.find { |s| s.edit == :checksum }
+      expect(checksum).to have_attributes(position: nil, to: lei[18, 2], confidence: nil)
+      expect(checksum.to_s).to eq(lei)
+    end
+  end
+
+  describe 'IBAN (mid-string checksum)' do
+    it 'yields a :checksum candidate for a wrong check field' do
+      suggestions = SecID::IBAN.suggest('DE00370400440532013000')
+      checksum = suggestions.find { |s| s.edit == :checksum }
+      expect(checksum).to have_attributes(position: nil, from: '00', to: '89', confidence: nil)
+      expect(checksum.to_s).to eq('DE89370400440532013000')
+    end
+
+    it 'filters out country-code edits that re-segment the BBAN boundary' do
+      # D->0 in the country code is a homoglyph but re-segments; valid? rejects it.
+      expect(SecID::IBAN.suggest('0E89370400440532013000')).to eq([])
+    end
+  end
+
+  describe 'DTI (alphabetic check, vowel-free alphabet)' do
+    it 'returns an in-charset homoglyph fix (S<->5) plus the :checksum fallback' do
+      suggestions = SecID::DTI.suggest('C5T3S80PV') # valid is CST3S80PV (5 at index 1 should be S)
+      fix = suggestions.find { |s| s.edit == :substitution && s.position == 1 }
+      expect(fix).to have_attributes(from: '5', to: 'S', confidence: :high, to_s: 'CST3S80PV')
+      expect(suggestions.last.edit).to eq(:checksum)
+    end
+
+    it 'returns only the :checksum fallback for an out-of-charset (O-for-0) typo' do
+      # 'O' is not in the DTI alphabet: the whole string fails valid_format? -> [].
+      expect(SecID::DTI.suggest('OST3S80PV')).to eq([])
+    end
+  end
+
+  describe 'property: across all 9 checksum types' do
+    checksum_types = %i[isin cusip sedol figi lei iban cei dti upi]
+
+    checksum_types.each do |key|
+      context "when repairing #{key}" do
+        let(:klass) { SecID[key] }
+        let(:alphanumeric) { ('0'..'9').to_a + ('A'..'Z').to_a }
+        # A single-character, format-valid but checksum-failing mutation of a generated
+        # identifier — a body typo the engine can repair, found for every type.
+        let(:corrupted) do
+          valid = klass.generate(random: Random.new(42)).to_s
+          candidates = valid.each_char.with_index.flat_map do |char, index|
+            (alphanumeric - [char]).map { |replacement| valid.dup.tap { |mutant| mutant[index] = replacement } }
+          end
+          # A format-valid but checksum-failing single-char typo — a body error to repair.
+          candidates.find do |c|
+            i = klass.new(c)
+            !i.valid? && i.send(:valid_format?)
+          end || raise("no mutation for #{klass}")
+        end
+        let(:suggestions) { klass.suggest(corrupted) }
+
+        it 'returns only valid, correctly-tiered candidates with the checksum fallback last' do
+          expect(suggestions).not_to be_empty
+          expect(suggestions).to all(satisfy { |s| s.identifier.valid? })
+          expect(suggestions.map(&:confidence)).to all(satisfy { |c| [:high, :medium, nil].include?(c) })
+          body_edits = suggestions.reject { |s| s.edit == :checksum }
+          expect(body_edits.map(&:confidence)).to all(satisfy { |c| %i[high medium].include?(c) })
+          expect(suggestions.last.edit).to eq(:checksum)
+        end
+      end
+    end
+  end
+end

--- a/spec/sec_id/suggestion_spec.rb
+++ b/spec/sec_id/suggestion_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SecID::Suggestion do
+  let(:isin) { SecID::ISIN.new('US5949181045') }
+  let(:suggestion) do
+    described_class.new(
+      type: :isin, identifier: isin, edit: :substitution,
+      position: 9, from: 'O', to: '0', confidence: :high
+    )
+  end
+
+  describe 'construction and readers' do
+    it 'exposes each field via keyword construction' do
+      expect(suggestion).to have_attributes(
+        type: :isin, identifier: isin, edit: :substitution,
+        position: 9, from: 'O', to: '0', confidence: :high
+      )
+    end
+
+    it 'is frozen and immutable' do
+      expect(suggestion.frozen?).to be(true)
+    end
+  end
+
+  describe 'value equality' do
+    it 'compares equal and shares a hash for identical fields' do
+      twin = suggestion.with
+      expect(suggestion).to eq(twin)
+      expect(suggestion.hash).to eq(twin.hash)
+    end
+
+    it 'is usable as a Hash key' do
+      expect({ suggestion => :found }[suggestion.with]).to eq(:found)
+    end
+
+    it 'differs when any field differs' do
+      expect(suggestion).not_to eq(suggestion.with(confidence: :medium))
+    end
+  end
+
+  describe '#to_h and #as_json' do
+    it 'returns the symbol-keyed field hash' do
+      expect(suggestion.to_h).to eq(
+        type: :isin, identifier: isin, edit: :substitution,
+        position: 9, from: 'O', to: '0', confidence: :high
+      )
+    end
+
+    it 'serializes as_json identically to to_h' do
+      expect(suggestion.as_json).to eq(suggestion.to_h)
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the corrected identifier string' do
+      expect(suggestion.to_s).to eq('US5949181045')
+    end
+  end
+
+  describe 'domain enumerations' do
+    it 'lists every edit kind the engine produces in EDIT_KINDS' do
+      produced = SecID::ISIN.suggest('US5499181045').map(&:edit).uniq
+      expect(produced - described_class::EDIT_KINDS).to be_empty
+      expect(described_class::EDIT_KINDS).to eq(%i[substitution transposition checksum])
+    end
+
+    it 'lists every non-nil confidence the engine produces in CONFIDENCE_LEVELS' do
+      produced = SecID::ISIN.suggest('US5499181045').map(&:confidence).compact.uniq
+      expect(produced - described_class::CONFIDENCE_LEVELS).to be_empty
+      expect(described_class::CONFIDENCE_LEVELS).to eq(%i[high medium])
+    end
+  end
+
+  describe 'edit-kind coordinate systems' do
+    it 'encodes a transposition as left index plus the swapped two-char substring' do
+      transposition = suggestion.with(edit: :transposition, position: 4, from: 'AB', to: 'BA', confidence: :medium)
+      expect(transposition).to have_attributes(edit: :transposition, position: 4, from: 'AB', to: 'BA')
+    end
+
+    it 'encodes a checksum recompute with a nil position and confidence' do
+      checksum = suggestion.with(edit: :checksum, position: nil, from: '0', to: '5', confidence: nil)
+      expect(checksum).to have_attributes(edit: :checksum, position: nil, confidence: nil)
+    end
+  end
+end

--- a/spec/sec_id_spec.rb
+++ b/spec/sec_id_spec.rb
@@ -545,4 +545,43 @@ RSpec.describe SecID do
       expect(result).to be_valid
     end
   end
+
+  describe '.suggest' do
+    it 'may span ISIN and UPI for a shared-bucket QZ-prefixed vowel-free input (AE5)' do
+      suggestions = described_class.suggest('QZRBG6ZTKS45')
+      expect(suggestions.map(&:type).uniq).to include(:isin, :upi)
+      expect(suggestions).to all(satisfy { |s| s.identifier.valid? })
+    end
+
+    it 'ranks ISIN before UPI on a tie (registration order)' do
+      suggestions = described_class.suggest('QZRBG6ZTKS45')
+      isin_checksum = suggestions.index { |s| s.type == :isin && s.edit == :checksum }
+      upi_checksum = suggestions.index { |s| s.type == :upi && s.edit == :checksum }
+      expect(isin_checksum).to be < upi_checksum
+    end
+
+    it 'drops UPI for a vowel-bearing 12-char input at the charset pre-filter' do
+      expect(described_class.suggest('US5949181040').map(&:type).uniq).to eq([:isin])
+    end
+
+    it 'restricts to the given checksum types' do
+      expect(described_class.suggest('QZRBG6ZTKS45', types: [:isin]).map(&:type).uniq).to eq([:isin])
+    end
+
+    it 'silently skips non-checksum types (no repair oracle)' do
+      expect(described_class.suggest('US5949181040', types: [:wkn])).to eq([])
+    end
+
+    it 'returns [] when no format-compatible checksum type matches' do
+      expect(described_class.suggest('ABC')).to eq([])
+    end
+
+    it 'returns [] for nil input' do
+      expect(described_class.suggest(nil)).to eq([])
+    end
+
+    it 'raises ArgumentError for an unknown type in types:' do
+      expect { described_class.suggest('US5949181040', types: [:nope]) }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Until now a mistyped securities identifier could only be validated — `valid?` says yes or no. This adds `suggest`, which turns that same checksum into a repair engine: for a structurally-valid but checksum-**failing** identifier it returns the plausible corrections, ranked by confidence.

```ruby
SecID::ISIN.suggest('US5949181O45').first
# => #<SecID::Suggestion type=:isin edit=:substitution position=9 from="O" to="0" confidence=:high>
#    .to_s        => "US5949181045"
#    .identifier  => #<SecID::ISIN ...>  (parsed and valid)

SecID.suggest('US5949181O45')                   # infers every format-compatible checksum type
SecID.suggest('US5949181O45', types: [:isin])   # or restrict to specific types
```

Available for all 9 checksum types (ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CEI, DTI, UPI), per class and via the central dispatcher.

## How it works

It enumerates the single-character errors a human or OCR actually makes — visual homoglyph substitutions (`O`↔`0`, `I`↔`1`, `5`↔`S`, `8`↔`B`, …) and adjacent transpositions — and keeps only the edits that re-validate. `valid?` is the oracle, so **no false candidate ever escapes**; the homoglyph table is the only recall lever.

Design decisions worth calling out:

- **Checksum-as-oracle, not a spell-checker.** Candidates are generated, then filtered by the type's own `valid?`. Precision comes for free; recall is bounded (and tunable) by the homoglyph table.
- **No `:low` tier.** Coincidental substitutions that merely happen to satisfy the checksum are never generated. Results stay in the tens per identifier and rank `:high` (homoglyph) then `:medium` (transposition) then a `:checksum` recompute fallback last.
- **One `Suggestable` concern, not nine copies.** It rides the existing checksum-as-oracle wiring and is `include`d only by the checksum types — non-checksum types (CIK, OCC, WKN, Valoren, CFI, FISN, BIC) have no oracle and therefore no `suggest`.
- **Additive and still zero-dependency.** New `SecID.suggest` / per-type `.suggest` plus a frozen `SecID::Suggestion` value object (mirroring `Scanner::Match`, with `to_h`/`as_json`/`deconstruct_keys` and `EDIT_KINDS`/`CONFIDENCE_LEVELS` for discovery). Nothing existing changes shape.

## Scope and limits

- **Never empty for structurally-valid input** — always at least the `:checksum` fallback. Only wrong-length or illegal-charset input (which fails the format gate) returns `[]`.
- **Single body error only** — two or more wrong characters, or an insertion/deletion, are out of scope.
- **Vowel-free reachability** — SEDOL/FIGI/DTI/UPI exclude vowels, so an `O`-for-`0` / `I`-for-`1` typo is unparseable and unrepairable; the mistyped character must be *in* the type's charset.
- `suggest` never mutates its input and never presents a candidate as an authoritative correction — the `confidence` tier is the caller's signal to weigh.

## Validation

- `bundle exec rake` green: RuboCop (0 offenses), RBS validate, and **2397 specs / 0 failures** — including named acceptance scenarios (AE1–AE5), a coincidental-exclusion property, per-type IBAN (mid-string checksum) / LEI (two-char checksum) / DTI (letter checksum) classification, and a property test spanning all 9 checksum types.
- Steep strict: no type errors; untyped-call coverage baseline held at 119; `rake rbs:test` 2392/0; YARD docs 100%.
- Precision simulation (`benchmark/suggest_precision.rb`, 1,000 seeded samples/type): every reachable single-error homoglyph or transposition that yields a checksum-failing identifier is recovered — the correct identifier is always among the returned candidates, and is the top-ranked body candidate ~89% of the time for homoglyph errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checksum-based typo repair suggestions for nine identifier types.
  * Suggestions identify likely substitutions, transpositions, and checksum corrections, ranked by confidence.
  * Added support for filtering suggestions by identifier type.
  * Added structured suggestion details, including the corrected identifier and edit metadata.
* **Documentation**
  * Added README and changelog guidance with usage examples and limitations.
* **Tests**
  * Added comprehensive coverage for suggestion generation, ranking, validation, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->