### PR TITLE
build: update dev dependencies and migrate to simplecov 1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,11 +27,16 @@ gem 'rubocop', '~> 1.88.0'
 gem 'rubocop-rspec', '~> 3.10.0'
 
 # Type signatures (sig/) — dev/test only; the gem keeps zero runtime dependencies.
-gem 'rbs', '~> 4.0', require: false
+#
+# rbs is held at 4.0.x: 4.1 retyped `Array#to_h`'s block return from the tuple `[K, V]` to the
+# `Hash::_Pair[K, V]` interface, and Steep 2.0 cannot infer an array literal as a tuple against an
+# interface hint, so `CFI::AttributeSet#to_h` stops type-checking. Tracked upstream in
+# https://github.com/soutaro/steep/issues/2253 — drop the patch pin once a Steep release fixes it.
+gem 'rbs', '~> 4.0.3', require: false
 gem 'steep', '~> 2.0', require: false
 
 # API documentation (rake yard) and the 100%-coverage gate (rake yard:stats) — dev/test only.
 gem 'yard', '~> 0.9', require: false
 
-gem 'simplecov', '~> 0.22', require: false
+gem 'simplecov', '~> 1.0', require: false
 gem 'simplecov-cobertura', require: false

--- a/lib/sec_id/active_model.rb
+++ b/lib/sec_id/active_model.rb
@@ -5,11 +5,11 @@ require 'sec_id'
 begin
   require 'active_model'
 rescue LoadError => e
-  # :nocov: ActiveModel is always loadable in the test suite
+  # simplecov:disable ActiveModel is always loadable in the test suite
   raise LoadError, 'sec_id/active_model requires ActiveModel, which could not be loaded. Add ' \
                    '`gem "activemodel"` to your Gemfile (or use this inside a Rails app) before ' \
                    "requiring 'sec_id/active_model'. (#{e.message})"
-  # :nocov:
+  # simplecov:enable
 end
 
 # ActiveModel validator for securities identifiers, registered under the `sec_id` key.
@@ -115,9 +115,10 @@ class SecIdValidator < ActiveModel::EachValidator
   # @return [String, nil] the message of the SecID::Error raised when normalizing `value` as `type`
   def capture_reason(type, value)
     SecID[type].normalize(value)
-    # :nocov: unreachable — only called after normalize already raised in valid_value?, kept as a safe fallback
+    # simplecov:disable unreachable — only called after normalize already raised in valid_value?,
+    # kept as a safe fallback
     nil
-    # :nocov:
+    # simplecov:enable
   rescue SecID::Error => e
     e.message
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ if ENV['COVERAGE']
   end
 
   SimpleCov.start do
-    add_filter { |src| !src.filename.start_with?("#{SimpleCov.root}/lib") }
+    skip { |src| !src.filename.start_with?("#{SimpleCov.root}/lib") }
   end
 end
 


### PR DESCRIPTION
## Description

Updates every outdated development dependency. `Gemfile.lock` is not tracked, so the routine bumps (Rails 8.1.3.1, RuboCop 1.88.2, YARD 0.9.45, parser 3.3.12.0, json 2.21.2, rspec-mocks 3.13.8, and others) appear only in the resolved lockfile. Three files change:

- **simplecov `~> 0.22` to `~> 1.0`.** This unblocks simplecov-cobertura 4.0, which requires simplecov `~> 1.0`.
- **`spec/spec_helper.rb`: `add_filter` to `skip`.** simplecov 1.0 deprecates `add_filter`. The matcher grammar is identical, so coverage is unchanged.
- **`lib/sec_id/active_model.rb`: `# :nocov:` to `# simplecov:disable` and `# simplecov:enable`.** simplecov 1.0 deprecates the `:nocov:` token and warns once per file at load time. Comments only, no behavior change.

### Why rbs stays on 4.0.x

rbs 4.1 retypes the block return of `Array#to_h` from the tuple `[K, V]` to the `Hash::_Pair[K, V]` interface. Steep 2.0 cannot infer an array literal as a tuple against an interface hint, so `CFI::AttributeSet#to_h` stops type-checking. This is tracked upstream in soutaro/steep#2253, which is open. The Gemfile pin carries the same explanation and names the condition for removing it.

Three workarounds were rejected:

- A `#:` type assertion type-checks, but makes `steep stats` report the file as an error. That trips the fail-closed `rake steep:coverage` gate.
- `map { ... }.to_h` type-checks, but RuboCop reports `Style/MapToHash`.
- `each_with_object` type-checks, but RuboCop reports `Style/ReduceToHash`.

The fix each cop offers is the block form Steep rejects, so `lib/sec_id/cfi/attribute_set.rb` is left untouched.

### Still outstanding

`diff-lcs` 2.0.0 is held at 1.6.2 by rspec-expectations, which requires `diff-lcs >= 1.2.0, < 2.0`. Nothing to do here until rspec relaxes it.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation update
- [x] Other: development dependency updates

## Checklist

- [x] Tests pass (`bundle exec rspec`)
- [x] RuboCop clean (`bundle exec rubocop`)
- [ ] CHANGELOG.md updated (under `[Unreleased]`) — skipped. Every change is dev and test tooling, invisible to gem consumers. The one `lib/` edit is comment text.
- [x] Documentation updated (if public API changed) — no public API change
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

## Validation

Run locally against the updated bundle:

- `rake` (RuboCop, `rbs validate`, 2397 examples) green
- `rake steep` reports no type error
- `rake steep:coverage` reports 119 untyped calls, exactly at the pinned baseline
- `rake rbs:test` green (2392 examples)
- `rake yard:stats` reports `100.00% documented`
- `COVERAGE=1 bundle exec rspec` reports 100% line coverage (1416 / 1416) with no simplecov deprecation warnings
- `CI=1 COVERAGE=1 bundle exec rspec` writes `coverage/coverage.xml` through simplecov-cobertura 4.0.0
- Rails 7.2, 8.0, and 8.1 gemfile variants each green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling compatibility settings.
  * Refined code coverage configuration and annotations.
* **Tests**
  * Updated coverage filtering to use the current supported configuration syntax.
  * Maintained existing coverage exclusions and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->