### PR TITLE
ci: publish from a tag-triggered workflow with trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+# Tag-triggered so the gem that ships is a commit that is in the repository and that CI
+# has tested, rather than whatever happened to be in a developer's working tree.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+env:
+  BUNDLE_FROZEN: 'true'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Test
+    timeout-minutes: 20
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    # No Bundler cache anywhere in this workflow: a restored cache is a poisoning vector
+    # in a tag-triggered publish, and releases are rare enough that the cost is nothing.
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+      with:
+        ruby-version: '4.0'
+        bundler-cache: false
+
+    - run: bundle install
+
+    - run: bundle exec rake
+
+  build:
+    runs-on: ubuntu-latest
+    name: Build
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+      with:
+        ruby-version: '4.0'
+        bundler-cache: false
+
+    # A tag that disagrees with SecID::VERSION would publish a version nobody can trace
+    # back to a tag, and the push cannot be undone. Fail here instead.
+    - name: Verify the tag matches SecID::VERSION
+      run: |
+        ruby -e 'tag = ENV.fetch("GITHUB_REF_NAME").delete_prefix("v");
+                 version = Gem::Specification.load("sec_id.gemspec").version.to_s;
+                 abort("tag v#{tag} does not match sec_id.gemspec #{version}") unless tag == version'
+
+    - run: mkdir -p pkg && gem build sec_id.gemspec --output pkg/sec_id.gem
+
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: built-gem
+        path: pkg/sec_id.gem
+        retention-days: 1
+
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish to RubyGems
+    needs: [test, build]
+    # Approval gate: the `release` environment requires a reviewer, and the RubyGems
+    # trusted publisher names this environment, so no token is minted before approval.
+    environment: release
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: built-gem
+        path: pkg/
+
+    # This job installs no Gemfile dependencies; it only needs a Ruby to run `gem`.
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+      with:
+        ruby-version: '4.0'
+        bundler-cache: false
+
+    # Exchanges this run's OIDC token for a short-lived publish token. No RubyGems API
+    # key is stored anywhere, so there is nothing to steal between releases.
+    - uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
+
+    # Explicit rather than implicit: signing behaviour varies by RubyGems client version,
+    # and this is the same tool and version rubygems/release-gem calls internally.
+    - name: Sign the gem with sigstore
+      run: gem exec --conservative sigstore-cli:0.2.3 sign pkg/sec_id.gem --bundle pkg/sec_id.gem.sigstore.json
+
+    - name: Push to RubyGems with provenance
+      run: gem push pkg/sec_id.gem --attestation pkg/sec_id.gem.sigstore.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,6 +443,17 @@ This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.
 3. Update `README.md` installation version if needed (e.g., `~> 4.3` to `~> 4.4`)
 4. Run `bundle exec rake lock:refresh` — the committed lockfiles record `sec_id` as a path
    gem at its current version, and CI installs frozen, so a stale lock fails every job
-5. Commit changes: `git commit -am "chore: bump version to X.Y.Z"`
-6. Release: `bundle exec rake release` — builds the gem, creates and pushes the git tag, pushes to RubyGems.org
-7. Create GitHub release at https://github.com/svyatov/sec_id/releases with notes from CHANGELOG
+5. Commit changes and open a PR: `main` requires a change request, so the bump cannot be pushed directly
+6. After merging, tag the merge commit: `git tag -a vX.Y.Z -m "Version X.Y.Z"` (signed automatically via `tag.gpgSign`) and `git push origin vX.Y.Z`
+7. Approve the `release` deployment when GitHub asks. The tag push starts `.github/workflows/release.yml`, which tests, builds, verifies the tag matches `SecID::VERSION`, and then waits for a reviewer before anything reaches RubyGems.org
+8. Create GitHub release at https://github.com/svyatov/sec_id/releases, pasting the CHANGELOG section for this version verbatim
+9. Verify the release:
+
+   ```bash
+   git tag -v vX.Y.Z                                                  # signature
+   curl -s https://rubygems.org/api/v1/attestations/sec_id-X.Y.Z.json # non-empty array
+   ```
+
+There is no local publish path. `rake release` is deliberately absent (see the `Rakefile` header);
+publishing runs only in CI, authenticated through RubyGems trusted publishing, so no API key exists
+on any machine.

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+# Deliberately no `require 'bundler/gem_tasks'`: it defines `rake release`, which builds,
+# tags, and pushes to RubyGems from whatever is in the working tree, on a long-lived
+# credential. Releasing happens in .github/workflows/release.yml, triggered by a tag.
+
 require 'English'
-require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'steep/rake_task'
@@ -86,12 +89,6 @@ task 'rbs:test' do
   # the instrumented run and pass having verified nothing.
   Rake::Task[:spec].reenable
   Rake::Task[:spec].invoke
-end
-
-Rake::Task['release:rubygem_push'].enhance(['fetch_otp'])
-
-task :fetch_otp do
-  ENV['GEM_HOST_OTP_CODE'] = `op item get "RubyGems" --account my --otp`.strip
 end
 
 # The platform the CI runners use, which a lock resolved on a developer machine misses.


### PR DESCRIPTION
Closes R-PUB-01, R-PUB-02 and R-PUB-04 from the oss-kit audit, and sets up R-PUB-03, which can only be verified after the next release actually runs.

## The change

Publishing moves off the developer machine into `.github/workflows/release.yml`, triggered by a `v*` tag push.

| Job | Holds | Does |
|---|---|---|
| `test` | nothing | `bundle exec rake` on the tagged commit |
| `build` | nothing | verifies the tag matches `SecID::VERSION`, `gem build`, uploads the artifact |
| `publish` | the RubyGems credential | downloads the artifact, signs it, pushes it |

That split is the design, not incidental structure. The job that produces the artifact never holds a credential, and the job that holds the credential never runs project code, installs Gemfile dependencies, or restores a Bundler cache. A restored cache in a credentialed tag-triggered run is a poisoning vector, and releases are rare enough that losing it costs nothing.

**Authentication (R-PUB-02).** `rubygems/configure-rubygems-credentials` exchanges the run's OIDC token for a short-lived publish token. No `RUBYGEMS_API_KEY` is stored anywhere, so there is nothing to steal between releases.

**Approval (R-PUB-04).** The publish job pins `environment: release`, which requires a reviewer and is restricted to `v*` tags. The trusted publisher names that environment too, which is what makes the gate load-bearing rather than decorative: without it, RubyGems would mint a token for any run of this workflow, approved or not.

**Provenance (R-PUB-03).** The gem is signed explicitly with `sigstore-cli 0.2.3`, the same tool and version `rubygems/release-gem` calls internally, then pushed with `--attestation`. Signing is explicit rather than implicit because the implicit behaviour varies by RubyGems client version.

**Version guard.** A tag that disagrees with `SecID::VERSION` fails the build job. A registry push cannot be undone, so the mismatch has to be caught before the gate rather than after it. Both paths tested locally: matching tag exits 0, `v9.9.9` against 7.1.0 aborts with the version in the message.

## The local publish path is removed

`require 'bundler/gem_tasks'` is gone, along with the 1Password OTP hook that fed it. It defined `rake release`, which built, tagged, and pushed from whatever was in the working tree on a long-lived credential. That is precisely what this replaces, and R-PUB-01 requires the publish command appear in no local script intended for manual use. A `Rakefile` header comment records why it is absent so it does not come back.

This also removes `rake build`, `rake install`, and `rake install:local`. Nothing in the repository referenced them.

## Before the next release

Two things must happen, in this order:

1. **Create the trusted publisher** at `https://rubygems.org/gems/sec_id/trusted_publishers/new`: owner `svyatov`, repository `sec_id`, workflow filename `release.yml`, environment `release`. This has no API, so it needs the web form. Until it exists the publish job fails at credential exchange; nothing else in the workflow depends on it.
2. **Delete any RubyGems API key** still provisioned for this gem, once a release has gone through the new flow.

The `release` environment already exists with a required reviewer and a `v*` tag restriction.

## Verifying after the first release

```bash
curl -s https://rubygems.org/api/v1/attestations/sec_id-X.Y.Z.json
```

A non-empty JSON array is R-PUB-03 passing. An empty array is a failed provenance check.

## Also here

`CLAUDE.md`'s release checklist is rewritten around the new flow: bump, PR (`main` now requires one), tag, approve, verify. It carries the signature and attestation checks as the closing step.