### PR TITLE
docs: state governance and route non-defect traffic to Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# The two issue templates cover defects and feature requests. Everything else has a home
+# in Discussions, and this file is the only place a newcomer finds out.
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/svyatov/sec_id/discussions/categories/q-a
+    about: Ask how to validate, parse, convert, or classify an identifier. Answers stay searchable here.
+
+  - name: Ideas and general discussion
+    url: https://github.com/svyatov/sec_id/discussions
+    about: Propose a new identifier standard, share what you built, or talk through an approach before opening an issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,19 @@ docs: update README with LEI usage examples
 - Follow existing code patterns and conventions
 - Update YARD documentation for the public API — 100% coverage is enforced in CI (`bundle exec rake yard:stats`)
 
+## Governance
+
+SecID has one maintainer, [Leonid Svyatov](https://github.com/svyatov), who reviews and merges every
+change and publishes every release. Decisions are theirs. There is no steering group, no vote, and no
+second person who can merge.
+
+No succession is arranged. If the maintainer stops, the project stops with them. The MIT license lets
+anyone fork and continue from the last published state, and that is the intended fallback rather than
+an oversight. This is stated plainly so you can weigh it before depending on the gem or investing in a
+contribution.
+
 ## Questions?
 
-Open a [GitHub issue](https://github.com/svyatov/sec_id/issues) for questions or discussion.
+Open a [discussion](https://github.com/svyatov/sec_id/discussions) for questions, ideas, and anything
+that is not a defect. The [issue tracker](https://github.com/svyatov/sec_id/issues) is for bug reports
+and feature requests.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,12 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-|---------|--------------------|
-| 5.x     | :white_check_mark: |
-| < 5.0   | :x:                |
+| Version | Supported |
+|---------|-----------|
+| 7.x     | Yes       |
+| < 7.0   | No        |
+
+Fixes land on the current major only. Older majors receive no backports.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Closes R-COM-08 and R-COM-09 from the oss-kit audit.

## Governance (R-COM-08)

A contributor deciding whether to invest and a user deciding whether to depend are asking the same two questions: who can merge and release, and does this survive its current maintainer. `CONTRIBUTING.md` now answers both in a short section: one maintainer decides, no succession is arranged, and the MIT license means anyone can fork and continue from the last published state.

That is the whole fix. The rule is satisfied by a single-maintainer project saying so, and naming a second maintainer or inventing a steering group would be worse than the silence it replaces.

## Issue chooser (R-COM-09)

Discussions has been enabled for a while with nothing in the repository pointing at it, so the forum stayed empty while every question arrived as an issue. `.github/ISSUE_TEMPLATE/config.yml` now offers two destinations:

| Entry | Destination |
|---|---|
| Question or usage help | the Q&A category, which is answerable so answers stay searchable |
| Ideas and general discussion | the top level, for anything else that is not a defect |

Both URLs return 200. `CONTRIBUTING.md`'s closing section routed everything to the issue tracker, which contradicted the new chooser, so it now splits the same way.

`blank_issues_enabled` is deliberately left unset. The rule scores the routing, not the tracker's front door, and disabling the blank issue is a separate decision that nobody asked for.

The two existing issue templates and the PR template are untouched; R-COM-05 already passed.

## Also here

`SECURITY.md` claimed 5.x was the supported line, against a 7.1.0 gem. That is worse than saying nothing, since a reporter on 6.x would read themselves as unsupported and not report. The table names the current major and states that older majors get no backports.

Its two emoji shortcodes (`:white_check_mark:` and `:x:`) are gone in the same edit. The prose sweep was scheduled for a later PR, but these are the same two lines, and touching them twice would just be churn.

## Not in scope

`CONTRIBUTING.md` still carries five em dashes and Title Case headings. Those belong to the prose sweep, which rewrites the file's headings wholesale.