### PR TITLE
docs: give the README a differentiator, a status, and a way to ask

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: release
+description: Cut a new sec_id release — version bump, changelog, lockfile refresh, PR, signed tag, and the approval-gated CI publish to RubyGems. Use when asked to release, cut a version, bump the version, or publish the gem.
+---
+
+# Releasing a New Version
+
+This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html):
+
+- **MAJOR** — breaking changes (incompatible API changes)
+- **MINOR** — new features (backwards-compatible)
+- **PATCH** — bug fixes (backwards-compatible)
+
+## Procedure
+
+1. Update `lib/sec_id/version.rb` with the new version number
+2. Update `CHANGELOG.md`: change `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD` and add a new empty `[Unreleased]` section
+3. Update `README.md` installation version if needed (e.g. `~> 4.3` to `~> 4.4`)
+4. Run `bundle exec rake lock:refresh` — the committed lockfiles record `sec_id` as a path gem at
+   its current version, and CI installs frozen, so a stale lock fails every job
+5. Commit changes and open a PR: `main` requires a change request, so the bump cannot be pushed directly
+6. After merging, tag the merge commit and push it:
+
+   ```bash
+   git tag -a vX.Y.Z -m "Version X.Y.Z"   # signed automatically via tag.gpgSign
+   git push origin vX.Y.Z
+   ```
+
+7. Approve the `release` deployment when GitHub asks. The tag push starts
+   `.github/workflows/release.yml`, which tests, builds, verifies the tag matches `SecID::VERSION`,
+   and then waits for a reviewer before anything reaches RubyGems.org
+8. Create the GitHub release at https://github.com/svyatov/sec_id/releases, pasting the CHANGELOG
+   section for this version verbatim
+9. Verify the release:
+
+   ```bash
+   git tag -v vX.Y.Z                                                  # signature
+   curl -s https://rubygems.org/api/v1/attestations/sec_id-X.Y.Z.json # non-empty array
+   ```
+
+## No local publish path
+
+`rake release` is deliberately absent (see the `Rakefile` header). Publishing runs only in CI,
+authenticated through RubyGems trusted publishing, so no API key exists on any machine. Do not add
+a local publish task.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,264 +2,108 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Everything derivable from the source lives in the source. This file carries only what reading the
+code cannot teach: contracts, rationale, gotchas, and repo conventions. Run `bundle exec rake -T`
+for the task list, and read `lib/` for the API.
+
 ## Build and Test Commands
 
-- **Run example scripts**: `bundle exec ruby examples/openfigi_lookup.rb`
-- **Run all tests**: `bundle exec rake spec` or `bundle exec rspec`
-- **Run single test file**: `bundle exec rspec spec/sec_id/isin_spec.rb`
-- **Run specific test**: `bundle exec rspec spec/sec_id/isin_spec.rb:42`
-- **Run linter**: `bundle exec rake rubocop` or `bundle exec rubocop`
-- **Safe auto-fix lint issues**: `bundle exec rubocop -a`
-- **Auto-fix ALL lint issues (potentially unsafe)**: `bundle exec rubocop -A`
-- **Run both lint and tests**: `bundle exec rake` (default task: `rubocop` + `rbs` + `spec`)
-- **Validate RBS signatures**: `bundle exec rake rbs` (also in the default task)
-- **Type-check (Steep, strict)**: `bundle exec rake steep`
+Standard invocations (`bundle exec rspec`, `rubocop`, `rake`, `bin/setup`, `bin/console`) work as
+expected. The non-obvious ones:
+
+- **Run tests with coverage**: `COVERAGE=1 bundle exec rspec` (opt-in via env var)
 - **Type coverage gate**: `bundle exec rake steep:coverage` (fails if untyped calls exceed the pinned baseline)
 - **Runtime signature check**: `bundle exec rake rbs:test` (runs the spec suite under RBS::Test)
 - **Regenerate CFI dynamic-method sigs**: `bundle exec rake sig:cfi`
-- **Generate API docs (YARD)**: `bundle exec rake yard` (HTML output in `doc/`, driven by `.yardopts`)
 - **Documentation coverage gate**: `bundle exec rake yard:stats` (fails unless 100% of the public API is documented; a CI step)
-- **Run tests with coverage**: `COVERAGE=1 bundle exec rspec`
-- **Run benchmarks**: `bundle exec rake bench` (validation/detection throughput + allocations; machine-dependent, for catching regressions)
-- **Install dependencies**: `bin/setup`
-- **Interactive console**: `bin/console`
+- **Run benchmarks**: `bundle exec rake bench` (machine-dependent, for catching regressions)
+- **Refresh lockfiles**: `bundle exec rake lock:refresh` (required after a version bump — see the release skill)
+
+The default `rake` task is `rubocop` + `rbs` + `spec`.
 
 ## Architecture
 
 This is a Ruby toolkit for securities identifiers (ISIN, CUSIP, CEI, SEDOL, FIGI, LEI, IBAN, CIK, OCC, WKN, Valoren, CFI, FISN, BIC, DTI, UPI) — validate, normalize, parse, detect, convert, generate, classify, calculate checksums, and repair. CFI is a full ISO 10962:2021 classifier (`CFI#decode`). Checksum-failing identifiers can be repaired via `suggest` (homoglyph + transposition candidates, confidence-ranked). Ships an opt-in ActiveModel/Rails validator that adds no runtime dependency to the zero-dependency core.
 
+All identifier classes inherit from `SecID::Base`, which includes the `Normalizable`, `Validatable`,
+and `Generatable` concerns. Checksum types additionally include `Checkable` and `Suggestable`.
+`Detector` and `Scanner` are `@api private`. Read the files for the method inventories.
+
 ### Directory Layout
 
-- `lib/` — gem source (shipped in the gem)
-- `sig/` — hand-written RBS type signatures mirroring the core `lib/` scope (shipped in the gem; see RBS Type Signatures below)
-- `tasks/` — build-time helpers not shipped in the gem (currently `cfi_signature_generator.rb`, shared by `rake sig:cfi` and the drift spec)
-- `spec/` — RSpec tests
-- `examples/` — runnable integration examples (not shipped in gem, linted by rubocop)
-- `docs/guides/` — lookup service integration guides (not shipped in gem)
-- `docs/solutions/` — documented solutions to past problems (bugs, best practices, design patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`); relevant when implementing or debugging in documented areas (not shipped in gem)
-- `CONCEPTS.md` — shared domain vocabulary (identifier anatomy, named processes); relevant when orienting to the codebase or discussing domain concepts
-- `sec_id.gemspec` `spec.files` includes `lib/**/*.rb`, `sig/**/*`, and select markdown files — `docs/` and `examples/` are intentionally excluded
+Standard gem layout. What `ls` doesn't tell you:
 
-### Class Hierarchy
+- `tasks/` — build-time helpers **not shipped in the gem** (currently `cfi_signature_generator.rb`, shared by `rake sig:cfi` and the drift spec)
+- `docs/solutions/` — documented solutions to past problems (bugs, best practices, design patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`); **read these when implementing or debugging in a documented area**
+- `CONCEPTS.md` — shared domain vocabulary (identifier anatomy, named processes); read when orienting to the codebase or discussing domain concepts
+- `sec_id.gemspec` `spec.files` ships `lib/**/*.rb`, `sig/**/*`, and select markdown — `docs/` and `examples/` are **intentionally excluded**
 
-All identifier classes inherit from `SecID::Base` (`lib/sec_id/base.rb`), a thin coordinator that includes three concerns:
-- `Normalizable` — normalization: `#normalized` / `#normalize`, `#normalize!`, `.normalize(id)`, `#to_s`, `#to_str`, `SEPARATORS`
-- `Validatable` — validation: `#valid?`, `#validate`, `#errors`, `#validate!`, `.valid?`, `.validate`, `.validate!`, `.error_class_for`, `ERROR_MAP`
-- `Generatable` — generation: `.generate(random:)`, `random_string(charset, length, random:)` helper, `ALPHA`/`DIGITS`/`ALPHANUMERIC` charset constants
+### Design constraints and gotchas
 
-Base itself keeps:
-- Class-level metadata methods: `type_key` (the registry symbol — single authority, read by the registry, `to_h`, `explain`, the validator, `Detector`, and `Scanner`), `short_name`, `full_name`, `id_length`, `example`, `has_checksum?`, and the `@api private` `detection_priority` (composite specificity sort key: checksum rank, `length_specificity`, registration order — `Float::INFINITY` for an unregistered class)
-- `attr_reader :full_id, :identifier`
-- `inherited` hook (auto-registration)
-- `initialize` (abstract, raises `NotImplementedError`)
-- `to_h` (returns `{ type:, full_id:, normalized:, valid:, components: }`)
-- `as_json(*)` — delegates to `to_h` for JSON serialization compatibility
-- `deconstruct_keys(_keys)` — returns `components` so every type destructures in `case/in`; the `keys` argument is ignored, validity is not consulted (unparseable input binds `nil` per key), and no `deconstruct` exists
-- `==`, `eql?`, `hash` — value equality based on `comparison_id` (type + normalized form); instances usable as Hash keys and in Sets
-- `components` (private, returns `{}` — subclasses override with type-specific attributes)
-- `parse` (private, regex matching + `@full_id` assignment)
+These are the decisions the code can't explain on its own.
 
-Each identifier class defines these metadata constants:
-- `FULL_NAME` — human-readable standard name (e.g. `"International Securities Identification Number"`)
-- `ID_LENGTH` — fixed length (`Integer`), valid length range (`Range`), or discrete valid lengths (`Array`, e.g. BIC's `[8, 11]`). `detector.rb` and `scanner.rb` read the shape via the shared `Base.length_values` (enumerable lengths) / `Base.length_specificity` (specificity weight) helpers; `validatable.rb#valid_length?` branches on the three shapes directly for its bounds check
-- `EXAMPLE` — representative valid identifier string
-- `VALID_CHARS_REGEX` — regex for valid character set (used by `detect_errors` fallback)
+**Type metadata**
+- `type_key` is the single authority for the registry symbol — read by the registry, `to_h`, `explain`, the validator, `Detector`, and `Scanner`. Don't introduce a second source.
+- `ID_LENGTH` has three legal shapes: fixed `Integer`, `Range`, or discrete `Array` (BIC's `[8, 11]`). `detector.rb`/`scanner.rb` read the shape via the shared `Base.length_values` / `Base.length_specificity` helpers; `validatable.rb#valid_length?` branches on all three directly.
+- `deconstruct_keys(_keys)` ignores its argument and does **not** consult validity — unparseable input binds `nil` per key. There is deliberately no `deconstruct`.
+- Equality is by `comparison_id` (type + normalized form), so instances work as Hash keys and in Sets.
 
-Classes with checksums include the `Checkable` concern, which adds:
-- `valid?` override that validates format and checksum
-- `restore` (returns full identifier string without mutation), `restore!` (mutates and returns `self`), `checksum`, `calculate_checksum` methods
-- Character-to-digit conversion maps and Luhn algorithm variants
-- Class-level `restore`, `restore!`, and `checksum` methods
+**Detection**
+- Detection is a three-stage pipeline: special-char dispatch (`/`→FISN, ` `→OCC, `*@#`→CUSIP), length lookup, then charset pre-filter before `valid?`. Adding a type means keeping all three consistent.
+- Specificity sorting reads `Base.detection_priority` (checksum rank, length specificity, registration order; `Float::INFINITY` when unregistered). `#matches?` and `#first_match` are fast paths that deliberately bypass the full sort — don't "simplify" them into it.
+- Detector and Scanner caches are invalidated when a new type registers.
 
-### Registry (`lib/sec_id.rb`)
+**Checksums**
+- Classes that include `Checkable` **must** implement `calculate_checksum`. A `NotImplementedError` from a concrete identifier class means that implementation is missing.
+- `checksum_width` defaults to `1`; LEI and IBAN override it to `2`. `restore`/`to_s` right-justify against it (`5` → `"05"`). IBAN overrides `restore`/`to_s` outright because its checksum sits mid-string, not at the end.
+- `mod31_30_check_char(base, alphabet, alphabet_value)` takes the alphabet as an **explicit argument** rather than reading `self.class::ALPHABET` — this avoids RBS's `UnknownConstant`. Don't refactor it back.
+- DTI's and UPI's check "digit" is a `String` (can be a letter), not an `Integer` — the only types where this differs. `Checkable`'s contracts are typed `Integer | String` to admit it.
+- DTI's `calculate_checksum` consults `GRANDFATHERED_CODES` before running ISO 7064 MOD 31,30. A hit means the registry's hand-assigned code (currently only Bitcoin, `4H95J0R2` → `4H95J0R2X`) beats the algorithmic result. Because `valid?`, `restore`, `restore!`, and `checksum` all route through `calculate_checksum`, this is honored API-wide.
+- UPI's `QZ` prefix is **structural** (enforced by the regex, failing as `:invalid_format`), not a restricted-prefix list. UPI shares the 12-char bucket with ISIN/FIGI: a digit-checked UPI that also satisfies ISIN's Luhn double-detects as `[:isin, :upi]` (ISIN first, since UPI registers later); a letter-checked UPI detects as `[:upi]` alone (KTD3).
 
-Identifier classes auto-register via `Base.inherited`. Access them through:
-- `SecID[:isin]` — look up class by symbol key (raises `ArgumentError` if unknown)
-- `SecID.identifiers` — all registered classes in load order
-- `SecID.valid?(str, types: nil)` — quick boolean validation against all or specific types
-- `SecID.detect(str)` — returns all matching type symbols sorted by specificity (e.g. `[:isin]`)
-- `SecID.parse(str, types: nil, on_ambiguous: :first)` — returns a typed instance for the most specific match (or `nil`); `on_ambiguous:` accepts `:first` (default), `:raise` (raises `AmbiguousMatchError`), `:all` (returns array of all matching instances)
-- `SecID.parse!(str, types: nil, on_ambiguous: :first)` — like `parse` but raises `InvalidFormatError` on failure
-- `SecID.extract(text, types: nil)` — finds identifiers in freeform text, returns `Array<Match>`
-- `SecID.scan(text, types: nil)` — lazy version of `extract`, returns `Enumerator<Match>`
-- `SecID.explain(str, types: nil)` — returns per-type validation results for debugging detection
-- `SecID.generate(key, random: Random.new)` — returns a generated, format-valid instance for a type symbol (raises `ArgumentError` on unknown type); generated values are valid in format only, not real securities
-- `SecID.suggest(str, types: nil)` — returns confidence-ranked `Suggestion` repair candidates for a checksum-failing identifier. Resolves candidate types via the format-only filters (`has_checksum?` + `length_values` + `VALID_CHARS_REGEX`, mirroring detector stages 2–3 — a checksum-failing string never survives `valid?`-based detection), runs each type's `.suggest`, flattens, and ranks cross-type by confidence tier then registration order. `types:` narrows to the given types (non-checksum types are silently dropped — no oracle). The private `suggestable_types` helper does the resolution
+**Generation**
+- **Generated values are format-valid only — they are not real, registered securities** (random country codes, FIGI prefixes, OCC dates, CFI attribute choices).
+- Each type defines a private class-level `generate_body(random)`. Checksum-less types (CFI, FISN, BIC) compose the complete identifier there; OCC overrides `generate` entirely via `OCC.build`; IBAN emits a `"00"` placeholder checksum that the default `generate` then restores.
+- FIGI resamples until its prefix is not in `RESTRICTED_PREFIXES`; IBAN only generates numeric-BBAN countries; CIK/Valoren use a random integer rather than a digit char-fill to avoid leading-zero bodies.
+- CFI samples each attribute position only from the letters `SecID::CFI::Tables` permits for that group (plus `X`), then applies the `ED` cross-position rule — so every generated code passes strict `valid?`.
 
-### Detector (`lib/sec_id/detector.rb`)
+**Repair (`Suggestable`)**
+- Deliberately **not** on `Base` (R9 requires non-checksum types to have no `.suggest`) and **not** folded into `Checkable` (one capability per concern). It is `include`d by the 9 checksum types.
+- `HOMOGLYPHS` is the sole substitution candidate space and the recall lever — tune it via `benchmark/suggest_precision.rb`.
+- The checksum is the oracle: only `self.class.new(candidate).valid?` survivors are returned. A valid candidate is **not** necessarily the intended correction.
+- Classification is **position-agnostic** — never assume a trailing checksum, because IBAN splices mid-string. Equal bodies → `:checksum`; one differing index → `:substitution` (`:high`); adjacent mutual swap → `:transposition` (`:medium`). No `:low` tier is ever generated.
+- Candidate sets stay in the tens (25/37/52 for a 12/20/22-char id) — this is the human-error net, not a full single-character net.
 
-`@api private` class that implements type detection via a three-stage pipeline:
-1. **Special-char dispatch** — `/` routes to FISN, ` ` to OCC, `*@#` to CUSIP
-2. **Length lookup** — pre-computed `Hash{Integer => Array<Class>}` from `ID_LENGTH` constants
-3. **Charset pre-filter** — survivors filtered by `VALID_CHARS_REGEX` before calling `valid?`
+**CFI classification**
+- All tables live in `SecID::CFI::Tables`, deeply frozen via `SecID::DeepFreeze.call`. `CATEGORIES`/`GROUPS`/`.categories`/`.groups_for`/`#category`/`#group` are all derived from it.
+- Attribute checks are **skipped when the group is already invalid**.
+- `CFI::Field` predicates are scoped to the field's own domain: `category.equity?` and `attributes.voting_right.voting?` answer, but an out-of-domain predicate raises `NoMethodError`. This scoping replaced the old flat category-wide value predicates (migrate to `cfi.decode.attributes.<meaning>.<value>?`).
+- Decoded field objects are reachable **only** through `#decode`. `CFI#category`/`#group` return bare symbols and `components`/`to_h` return raw letters — deliberately unchanged.
+- `AttributeSet` omits pure-N/A positions and decodes `X` to `:not_applicable`.
 
-Specificity sort: reads each class's `Base.detection_priority` (checksum types first, then smaller length range, then load order).
+**Errors**
+- `Validatable::ERROR_MAP` maps error codes to exception classes; unmapped codes default to `InvalidFormatError`.
+- `#validate!` returns `self` on success and raises on the **first** error.
 
-Fast paths bypass the full sort: `#matches?` (used by `SecID.valid?`) short-circuits on the first valid candidate; `#first_match` (used by `SecID.parse`) builds the winning instance once and selects it via `min_by`, avoiding a second instantiation.
+### ActiveModel / Rails Validator
 
-Lazily instantiated from `SecID.detect`; cache invalidated when new types register.
+Optional, opt-in adapter — **never on the default `require 'sec_id'` path**, so the gem keeps zero runtime dependencies (ActiveModel/railties are dev/test deps only). `lib/sec_id/railtie.rb` is loaded only by the guarded last line of `lib/sec_id.rb`, which is inert outside Rails.
 
-### Scanner (`lib/sec_id/scanner.rb`)
+- `::SecIdValidator` is a **top-level** constant (so ActiveModel's `sec_id` → `SecIdValidator` lookup resolves it) — distinct from the `SecID` module. Don't namespace it.
+- `check_validity!` fails fast at class-load on an unknown type, both `type:`/`types:` together, or an empty `types:`.
+- `normalize: true` switches to the separator-lenient path and writes the canonical string back on success; agnostic/allowlist ambiguity resolves to the first matching type in registration/allowlist order (KTD5).
+- No locale files ship. The only i18n override point is the attribute-scoped key `activemodel.errors.models.<model>.attributes.<attr>.sec_id` — the generic `errors.messages.sec_id` is **not** consulted. `message:` is the general override.
+- The Rails-version matrix (7.2, 8.0, 8.1, head) runs via `gemfiles/rails_*.gemfile`, each `eval_gemfile`ing the root `Gemfile`; the root `Gemfile` only declares `activemodel`/`railties` unpinned when not run through a `gemfiles/` variant. `rails_head` is `continue-on-error`.
 
-`@api private` class that finds identifiers in freeform text. Uses a composite regex with three named groups (FISN, OCC, simple tokens) and cursor-based overlap prevention. Candidates are length-filtered, charset-filtered, and validated, then the most specific match is returned as a `Match` data object (`Data.define(:type, :raw, :range, :identifier)`).
+### v7 Deprecation Bridge (`deprecation.rb`)
 
-Lazily instantiated from `SecID.scan`/`SecID.extract`; cache invalidated when new types register.
+The v7 rename of the check-digit concept to `checksum` keeps the pre-v7 names working through v7 (all removed in v8; the `Checkable` concern name itself is unchanged):
 
-### Suggestion value object (`lib/sec_id/suggestion.rb`)
-
-`Suggestion = Data.define(:type, :identifier, :edit, :position, :from, :to, :confidence)` — the frozen record `suggest` returns, mirroring `Scanner::Match` (flat immutable `Data`, not the hand-rolled CFI value classes). `identifier` is the valid, parsed `SecID::Base` instance (so callers get `.to_s`, `.to_h`, `.country_code` for free); `edit` is `:substitution` / `:transposition` / `:checksum`. Coordinate system: `:substitution` — `position` is the 0-based index, `from`/`to` the single changed characters; `:transposition` — `position` is the left index, `from`/`to` the two-character adjacent substring before/after the swap; `:checksum` — `position` is `nil`, `from`/`to` the old/new check-character string, `confidence` is `nil`. `Data` supplies `==`/`hash`/`to_h`/`deconstruct_keys`; the reopened `class Suggestion` block (not the `Data.define` block, so Steep types `self` as the instance) adds `as_json(*) => to_h`, `to_s => identifier.to_s`, and the runtime-introspectable domain enumerations `EDIT_KINDS` (`%i[substitution transposition checksum]`, rank order) and `CONFIDENCE_LEVELS` (`%i[high medium]`; `:checksum` candidates carry `nil`) — mirroring `Validatable::ERROR_MAP`'s discoverability role so consumers enumerate legal values instead of parsing docs.
-
-### ActiveModel / Rails Validator (`lib/sec_id/active_model.rb`, `lib/sec_id/railtie.rb`)
-
-Optional, opt-in adapter — **never on the default `require 'sec_id'` path**, so the gem keeps zero runtime dependencies (ActiveModel/railties are dev/test deps only).
-
-- `lib/sec_id/active_model.rb` defines a top-level `::SecIdValidator < ActiveModel::EachValidator` (top-level constant so ActiveModel's `sec_id` → `SecIdValidator` lookup resolves it; distinct from the `SecID` module). It requires `active_model`, re-raising a clear `LoadError` if absent. `check_validity!` resolves `type:`/`types:` via `SecID[]` (fail-fast `ArgumentError` at class-load on unknown type, both keys together, or an empty `types:`). `validate_each` is strict by default (`SecID.valid?`); `normalize: true` switches to the separator-lenient `SecID[t].normalize` path and writes the canonical string back on success (agnostic/allowlist ambiguity resolves to the first matching type in registration/allowlist order — KTD5); `details: true` (single `type:` only) surfaces sec_id's specific failure reason. The error is added under the i18n key `:sec_id` with a built-in type-aware English default (`DEFAULT_MESSAGE`, `%{type_name}` interpolation) supplied as ActiveModel's `message:` fallback — no locale files shipped, so the only i18n override point is the attribute-scoped key `activemodel.errors.models.<model>.attributes.<attr>.sec_id` (the generic `errors.messages.sec_id` is not consulted); `message:` is the general override.
-- `lib/sec_id/railtie.rb` defines `SecID::Railtie < Rails::Railtie` with an `initializer` that requires `sec_id/active_model` after the framework boots. It is loaded only by the guarded last line of `lib/sec_id.rb` (`require 'sec_id/railtie' if defined?(Rails::Railtie)`), which is inert outside Rails.
-- CI verifies the adapter across a Rails-version matrix (7.2, 8.0, 8.1, head) on Ruby 4.0 via `gemfiles/rails_*.gemfile` (each `eval_gemfile`s the root `Gemfile` and pins `activemodel`/`railties`; the root `Gemfile` only declares them unpinned when not run through a `gemfiles/` variant). `rails_head` is `continue-on-error`.
-
-### Concerns (`lib/sec_id/concerns/`)
-
-#### Normalizable (`normalizable.rb`)
-
-Provides normalization and display formatting methods. Defines `SEPARATORS` constant (`/[\s-]/` by default).
-- Class methods: `normalize(id)`, `to_pretty_s(id)`
-- Instance methods: `normalized`, `normalize` (alias), `normalize!`, `to_pretty_s`, `to_s`, `to_str`
-- `to_pretty_s` returns a human-readable formatted string or `nil` for invalid input; subclasses override for type-specific formatting (IBAN/LEI: 4-char groups, ISIN/CUSIP/FIGI: component-separated, OCC: space-separated components, Valoren: thousands grouping)
-
-#### Validatable (`validatable.rb`)
-
-Provides validation methods. Defines `ERROR_MAP` constant (maps error code symbols to exception classes).
-- Class methods: `valid?(id)`, `validate(id)` (returns instance), `validate!(id)`, `error_class_for(code)`
-- Instance methods: `valid?`, `validate` (eagerly triggers errors, returns self), `errors` (memoized, returns `Errors`), `validate!`
-- Private methods: `valid_format?`, `error_codes`, `detect_errors`, `valid_length?`, `valid_characters?`, `checksum_width`, `validation_message`, `build_error`
-
-#### Checkable (`checkable.rb`)
-
-Provides checksum validation and calculation for identifiers with checksums. Include this in classes that have a checksum (ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CEI, DTI, UPI).
-
-Constants:
-- `CHAR_TO_DIGITS` - Multi-digit mapping for ISIN (letters expand to two digits)
-- `CHAR_TO_DIGIT` - Single-digit mapping (A=10, B=11, ..., Z=35)
-
-Luhn algorithm variants (private):
-- `luhn_sum_double_add_double(digits)` - Used by CUSIP and CEI
-- `luhn_sum_indexed(digits)` - Used by FIGI
-- `luhn_sum_standard(digits)` - Used by ISIN
-- `reversed_digits_single(id)` - Converts identifier to reversed digit array (single-digit mapping)
-- `reversed_digits_multi(id)` - Converts identifier to reversed digit array (multi-digit mapping for ISIN)
-
-Validation overrides (private):
-- `error_codes` - Returns `[:invalid_checksum]` when format is valid but checksum doesn't match
-- `checksum_width` - Returns `1` (used by `Validatable#valid_length?` to allow optional checksum in length check; LEI and IBAN override → `2`)
-
-`restore` and `to_s` use `checksum_width` to right-justify the checksum string (e.g. `5` → `"05"` for width 2). IBAN overrides `restore`/`to_s` because its checksum is mid-string.
-
-Helper methods (private):
-- `mod10`, `div10mod10`, `mod97` - Checksum calculation helpers
-- `mod31_30_check_char(base, alphabet, alphabet_value)` - Shared ISO 7064 hybrid MOD 31,30 walker, parameterized by alphabet (explicit args, not `self.class::ALPHABET`, to avoid RBS's `UnknownConstant`); used by DTI and UPI
-- `validate_format_for_calculation!` - Raises error if format invalid
-
-#### v7 Deprecation Bridge (`deprecation.rb`)
-
-The v7 rename of the check-digit concept to `checksum` ships a bridge that keeps the pre-v7 names working through v7 (all removed in v8; the `Checkable` concern name itself is unchanged):
-- `SecID::Deprecation.warn(old:, new:, removed_in: 'v8')` (`lib/sec_id/deprecation.rb`) emits one `Kernel#warn` per call — no dedup, visible at Ruby's default verbosity (silenced by `-W0` / `$VERBOSE = nil`). No `category:` is passed, because `Warning[:deprecated]` defaults off and would hide the migration signal.
-- Deprecated method aliases warn then delegate: instance/class `check_digit` → `checksum`, `calculate_check_digit` → `calculate_checksum`, class-level `has_check_digit?` → `has_checksum?`. Written as explicit typed methods (not metaprogrammed) so Steep sees both name sets and `STEEP_UNTYPED_BASELINE` holds. The per-type sigs narrow the deprecated `calculate_check_digit`/`self.check_digit` to the same concrete return type as their canonical counterparts (`Integer`, or `String` for DTI/UPI), so callers still on the old names during v7 keep full type precision; the `check_digit` reader stays the unified `(Integer | String)?` (an `attr_reader` can't be narrowed per subclass).
-- `SecID::InvalidCheckDigitError` is a constant alias of `InvalidChecksumError` (same class object, so `rescue` under either name keeps working).
-- `to_h`/`deconstruct_keys` carry both `:checksum` and a mirrored `:check_digit` key through v7 via the single `Base#components_with_deprecation_bridge` wrapper — each type's own `components` returns only `:checksum`, and the wrapper mirrors the canonical value (so the deprecated reader never fires internally). v8 removal is a one-file revert: drop the wrapper and point `to_h`/`deconstruct_keys` back at `components`.
+- `SecID::Deprecation.warn` emits one `Kernel#warn` per call — no dedup. It passes **no** `category:`, because `Warning[:deprecated]` defaults off and would hide the migration signal.
+- Deprecated aliases are written as explicit typed methods, **not** metaprogrammed, so Steep sees both name sets and `STEEP_UNTYPED_BASELINE` holds. Per-type sigs narrow the deprecated `calculate_check_digit`/`self.check_digit` to the same concrete return type as their canonical counterparts; the `check_digit` reader stays the unified `(Integer | String)?` (an `attr_reader` can't be narrowed per subclass).
+- `SecID::InvalidCheckDigitError` is a constant alias of `InvalidChecksumError` — the same class object, so `rescue` under either name works.
+- `to_h`/`deconstruct_keys` carry both `:checksum` and a mirrored `:check_digit` through the single `Base#components_with_deprecation_bridge` wrapper. Each type's own `components` returns only `:checksum`, so the deprecated reader never fires internally. **v8 removal is a one-file revert**: drop the wrapper and point `to_h`/`deconstruct_keys` back at `components`.
 - The `:invalid_check_digit` error code flips hard to `:invalid_checksum` with **no** dual emission (dual would duplicate `errors.details` entries). See `MIGRATION.md` for the matcher change.
-
-#### Generatable (`generatable.rb`)
-
-Provides generation of new, format-valid identifiers for use as test fixtures. Included in `Base`, so every type inherits a `.generate` entry point. **Generated values are valid in format only — they are not real, registered securities** (random country codes, FIGI prefixes, OCC dates, CFI category/group/attribute choices).
-
-Constants (charset building blocks): `ALPHA`, `DIGITS`, `ALPHANUMERIC`.
-
-Class methods (added via `included`/`extend(ClassMethods)`):
-- `generate(random: Random.new)` - Builds `new(generate_body(random))`, then calls `restore!` when `has_checksum?` is true, else returns the instance
-- `random_string(charset, length, random:)` (private) - Draws `length` characters from `charset` using `Array#sample(random:)`
-
-Per-type hooks:
-- Each type defines a private class-level `generate_body(random)` returning a valid body (identifier without checksum); checksum types' bodies are restored by the default `generate`
-- Checksum-less types (CFI, FISN, BIC) compose the complete identifier in `generate_body`; no `restore!` is called
-- IBAN composes a full-length body with a placeholder `"00"` checksum in `generate_body`; the default `generate` then calls `restore!` to replace them with the real two-digit check value
-- OCC overrides `generate` entirely (via `OCC.build`)
-- FIGI resamples its prefix until it is not in `RESTRICTED_PREFIXES`; IBAN generates only numeric-BBAN countries (`NUMERIC_COUNTRY_RULES`); CIK/Valoren use a random integer (not a digit char-fill) to avoid leading-zero bodies
-- CFI samples each attribute position only from the letters `SecID::CFI::Tables` permits for that group (plus `X`; pure-N/A positions yield only `X`, so `K`'s `XXXX` falls out), then applies the `ED` cross-position rule — so every generated code passes strict `valid?`
-
-#### Suggestable (`suggestable.rb`)
-
-The repair engine for checksum-failing identifiers, opt-in `include`d by the 9 checksum types (**not** on `Base` — R9 requires non-checksum types to have no `.suggest`; and **not** folded into `Checkable`, keeping the one-capability-per-concern convention). Adds instance `#suggest` and, via `self.included(base) -> base.extend(ClassMethods)`, class-level `.suggest(str)` (which is `new(str).suggest`).
-
-- Constants: `HOMOGLYPHS` (a frozen `Hash[String, Array[String]]` — the bidirectional homoglyph/OCR confusion table that drives enumeration *and* is the sole substitution candidate space; the recall lever, tuned via `benchmark/suggest_precision.rb`); `RANK` (`{ substitution: 0, transposition: 1, checksum: 2 }`).
-- `#suggest` returns `[]` when the input is already `valid?` (nothing to repair) or not `valid_format?` (unparseable). Otherwise it enumerates, per position, the character's `HOMOGLYPHS` substitutions plus adjacent transpositions, adds the `restore` result (the `:checksum` fallback, guaranteeing the two-character-check case for LEI/IBAN), dedupes, keeps only `self.class.new(candidate).valid?` (the oracle — no checksum-invalid candidate escapes, though a valid candidate is not necessarily the intended correction), classifies each survivor, and sorts by `RANK`.
-- Classification is **position-agnostic** (never assumes a trailing checksum — IBAN splices mid-string): `candidate.identifier == identifier` (equal bodies) → `:checksum`; else a single differing index → `:substitution` (`:high`), or an adjacent mutual swap → `:transposition` (`:medium`). No `:low`/coincidental tier is ever generated. `checksum_suggestion` renders `from`/`to` via `checksum` + private `checksum_width` (so a 2-char check reports the full field).
-- Candidate sets stay in the tens per identifier (25/37/52 for a 12/20/22-char id), not hundreds — the human-error net, not a full single-character net.
-
-### Identifier Classes
-
-Each identifier type (`lib/sec_id/*.rb`) implements:
-- `ID_REGEX` constant with named capture groups for parsing
-- `initialize` that calls `parse` and extracts components
-- Type-specific attributes (e.g., `country_code`, `nsin` for ISIN; `cusip6`, `issue` for CUSIP)
-- Private `components` method returning a hash of parsed attributes (read by both `#to_h` and `#deconstruct_keys`); classes with no type-specific attributes (CIK, WKN, Valoren) inherit the empty `{}` default
-
-**Classes with checksums** (ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CEI, DTI, UPI):
-- Include `Checkable` **and** `Suggestable` concerns (the repair engine rides the checksum-as-oracle, so the two are wired together across all 9)
-- Implement `calculate_checksum` with standard-specific algorithm
-- LEI and IBAN override `checksum_width` → `2` (two-character checksum)
-- DTI's and UPI's check "digit" is a `String` (can be a letter), not an `Integer` — the only types where this differs; `Checkable`'s `checksum`/`calculate_checksum` contracts are typed `Integer | String` to admit it
-
-**Classes without checksums** (CIK, OCC, WKN, Valoren, CFI, FISN, BIC):
-- Do not include `Checkable`
-- Validation based solely on format (CFI additionally validates its category/group/attribute tables strictly — see below)
-
-**Type-specific normalization overrides:**
-- CIK: `normalized` returns `@identifier.rjust(10, '0')`; `normalize!` also updates `@padding`
-- Valoren: `normalized` returns `@identifier.rjust(9, '0')`; `normalize!` also updates `@padding`
-- OCC: `normalized` returns `compose_symbol(underlying, date_str, type, strike_mills)` (pads underlying to 6 chars)
-- OCC, FISN: override `SEPARATORS = /-/` (spaces are structural in these formats)
-
-**Type-specific validation overrides:**
-- FIGI: `detect_errors` returns `:invalid_prefix` for restricted prefixes (BS, BM, GG, GB, GH, KY, VG)
-- CFI: strict ISO 10962:2021 validation — `detect_errors` returns `:invalid_category`, `:invalid_group`, and/or `:invalid_attribute` (impermissible attribute letter, `K` code missing `XXXX`, or an `ED` cross-position rule violation); attribute checks are skipped when the group is already invalid. All tables live in `SecID::CFI::Tables` (`lib/sec_id/cfi/tables.rb`), deeply frozen via `SecID::DeepFreeze.call` (`lib/sec_id/deep_freeze.rb`, a shared recursive Hash/Array freezer also used to freeze `CFI::CATEGORIES`/`GROUPS`); `CATEGORIES`/`GROUPS`/`.categories`/`.groups_for`/`#category`/`#group` are derived from it. `#decode` returns a frozen `CFI::Classification` (`lib/sec_id/cfi/classification.rb`); returns `nil` for an invalid CFI. Its `#category`, `#group`, and each attribute are `CFI::Field` objects (`lib/sec_id/cfi/field.rb`: `#code` letter, `#name` symbol, `#label` ISO string, `#meaning`, `#to_s`/`#to_h`/`#as_json`) that define a `<name>?` predicate per symbol in the field's own domain — so `category.equity?` and `attributes.voting_right.voting?` answer, but an out-of-domain predicate raises `NoMethodError` (this scoping is what replaced the old flat value-predicates). `#attributes` is a frozen `CFI::AttributeSet` (`lib/sec_id/cfi/attribute_set.rb`) — an `Enumerable` of the attribute fields with per-meaning readers (`attributes.voting_right`) and nil-safe `#[]` (`attributes[:form]`), keyed by each position's group meaning; pure-N/A positions are omitted and `X` decodes to `:not_applicable`. `Classification#to_h`/`#as_json` serialize the nested field hashes. `CFI#category`/`#group` (bare symbols) and `components`/`to_h` (raw letters) are unchanged — decoded field objects are reachable only through `#decode`. The old category-wide equity predicates were removed (migrate to `cfi.decode.attributes.<meaning>.<value>?`)
-- IBAN: `detect_errors` returns `:invalid_bban` when BBAN format doesn't match country rules; `.supported_countries` returns sorted array of all supported country codes
-- OCC: `error_codes` returns `:invalid_date` when date string can't be parsed
-- BIC: `detect_errors` returns `:invalid_country` when positions 5-6 are not in the recognized set (`lib/sec_id/bic/country_codes.rb`); `.countries` returns the sorted frozen set of recognized ISO 3166 / SWIFT country codes
-- DTI: `calculate_checksum` consults `GRANDFATHERED_CODES` (a frozen `Hash[String, String]`, base → registered code) before running the ISO 7064 hybrid MOD 31,30 algorithm; a hit means the registry's hand-assigned code (currently only Bitcoin, `4H95J0R2` → `4H95J0R2X`) wins over the algorithmic result, and this is honored API-wide (`valid?`, `restore`, `restore!`, `checksum`) since they all route through `calculate_checksum`
-- UPI (ISO 4914): 12 characters — fixed `QZ` prefix + 9-character body + 1 check character, all drawn from DTI's 30-symbol alphabet; `calculate_checksum` runs the shared `Checkable#mod31_30_check_char` over the 11 preceding characters (no grandfathered codes, no first-char restriction). A non-`QZ` string fails as `:invalid_format` via the regex (the prefix is structural, not a restricted-prefix list). Shares the 12-char length bucket with ISIN/FIGI: a digit-checked UPI that also satisfies ISIN's Luhn double-detects `[:isin, :upi]` (ISIN first, since UPI registers after it); a letter-checked UPI detects as `[:upi]` alone (KTD3)
-
-### Conversion Methods
-
-- `ISIN#to_cusip` - Convert ISIN to CUSIP (for CGS country codes only)
-- `ISIN#to_sedol` - Convert ISIN to SEDOL (for GB, IE, GG, IM, JE, FK country codes)
-- `ISIN#to_wkn` - Convert ISIN to WKN (for DE country code)
-- `ISIN#to_valoren` - Convert ISIN to Valoren (for CH/LI country codes)
-- `CUSIP#to_isin(country_code)` - Convert CUSIP to ISIN
-- `SEDOL#to_isin(country_code = 'GB')` - Convert SEDOL to ISIN (supports GB, IE, GG, IM, JE, FK)
-- `WKN#to_isin(country_code = 'DE')` - Convert WKN to ISIN
-- `Valoren#to_isin(country_code = 'CH')` - Convert Valoren to ISIN (supports CH, LI)
-
-### Errors (`lib/sec_id/errors.rb`)
-
-Frozen, immutable value object returned by `#errors`. Contains:
-- `details` — array of `{ error: Symbol, message: String }` hashes (frozen)
-- `messages` — array of human-readable error message strings
-- `none?` — true when no errors
-- `any?` / `empty?` / `size` — collection-like query methods
-- `each` — yields each error detail hash
-- `to_a` — alias for `messages`
-- `as_json(*)` — delegates to `details` for JSON serialization compatibility
-
-### Error Handling
-
-- `SecID::Error` - Base error class
-- `SecID::InvalidFormatError` - Raised by `validate!` for format errors (`:invalid_length`, `:invalid_characters`, `:invalid_format`) and by `calculate_checksum` on invalid format
-- `SecID::InvalidChecksumError` - Raised by `validate!` for `:invalid_checksum` (aliased as the deprecated `SecID::InvalidCheckDigitError` through v7 — see the v7 Deprecation Bridge)
-- `SecID::InvalidStructureError` - Raised by `validate!` for type-specific structural errors (`:invalid_prefix`, `:invalid_category`, `:invalid_group`, `:invalid_attribute`, `:invalid_bban`, `:invalid_date`, `:invalid_country`)
-- `SecID::AmbiguousMatchError` - Raised by `parse`/`parse!` when `on_ambiguous: :raise` and multiple types match
-- `Validatable::ERROR_MAP` maps error code symbols to exception classes; unmapped codes default to `InvalidFormatError`
-- `#validate!` returns `self` on success, raises on first error; `.validate!` returns the instance
-- **Important:** Classes that include `Checkable` must implement `calculate_checksum`. If `NotImplementedError` is raised from a concrete identifier class, it indicates a missing implementation.
 
 ### RBS Type Signatures (`sig/`)
 
@@ -289,96 +133,27 @@ When editing `lib/` in the typed scope, update the corresponding `sig/` file and
 
 ### Method Ordering (Stepdown Rule)
 
-Follow the "Stepdown Rule" from Clean Code: methods should be ordered so that callers appear before callees. Code should read top-to-bottom like a newspaper article—high-level concepts first, implementation details below.
-
-```ruby
-# Good - caller before callee, reads top-to-bottom
-def validate
-  check_format
-  check_value
-end
-
-def check_format
-  parse_components
-end
-
-def check_value
-  # ...
-end
-
-def parse_components
-  # ...
-end
-
-# Bad - callees appear before callers
-def parse_components
-  # ...
-end
-
-def check_format
-  parse_components
-end
-
-def validate
-  check_format
-  check_value
-end
-```
+Follow the "Stepdown Rule" from Clean Code: methods are ordered so that callers appear before
+callees. Code reads top-to-bottom like a newspaper article — high-level concepts first,
+implementation details below. So `validate` comes before `check_format`, which comes before
+`parse_components`; never the reverse.
 
 ## Commit Message Convention
 
-This project follows [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+This project follows [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/):
+`<type>[optional scope]: <description>`, with the standard type set (`feat`, `fix`, `docs`, `style`,
+`refactor`, `perf`, `test`, `build`, `ci`, `chore`).
 
-Format: `<type>[optional scope]: <description>`
-
-### Types
-
-| Type | Description | Version bump |
-|------|-------------|--------------|
-| `feat` | New feature | MINOR |
-| `fix` | Bug fix | PATCH |
-| `docs` | Documentation only | — |
-| `style` | Formatting, whitespace | — |
-| `refactor` | Code change (no feature/fix) | — |
-| `perf` | Performance improvement | — |
-| `test` | Adding/fixing tests | — |
-| `build` | Build system or dependencies | — |
-| `ci` | CI configuration | — |
-| `chore` | Maintenance tasks | — |
-
-### Breaking Changes
-
-Use `!` after type or add `BREAKING CHANGE:` footer. Breaking changes trigger a MAJOR version bump.
-
-### Examples
-
-```
-feat: add WKN support
-fix: correct CUSIP checksum for alphanumeric input
-docs: update README with LEI usage examples
-refactor: extract shared Normalizable module
-feat!: rename full_id to identifier across all classes
-chore: bump version to 4.4.0
-```
+Breaking changes use `!` after the type or a `BREAKING CHANGE:` footer, and trigger a MAJOR bump.
 
 ## Changelog Format
 
 This project follows [Keep a Changelog v1.1.0](https://keepachangelog.com/en/1.1.0/).
 
-Allowed categories in **required order**:
-
-1. **Added** — new features
-2. **Changed** — changes to existing functionality
-3. **Deprecated** — soon-to-be removed features
-4. **Removed** — removed features
-5. **Fixed** — bug fixes
-6. **Security** — vulnerability fixes
-
-Rules:
-- Categories must appear in the order listed above within each release section
-- Each category must appear **at most once** per release section — always append to an existing category rather than creating a duplicate
+- Categories must appear in this order within each release section: **Added**, **Changed**, **Deprecated**, **Removed**, **Fixed**, **Security**
+- Each category appears **at most once** per release section — always append to an existing category rather than creating a duplicate
 - Do NOT use non-standard categories like "Updated", "Internal", or "Breaking changes"
-- Breaking changes should be prefixed with **BREAKING:** within the relevant category (typically Changed or Removed)
+- Breaking changes are prefixed with **BREAKING:** within the relevant category (typically Changed or Removed)
 
 ## Documentation Style
 
@@ -389,19 +164,11 @@ All classes and methods must have YARD documentation. Follow these conventions:
 - Document all private methods with params and return types, add description for complex logic
 - Include `@example` blocks for non-obvious usage patterns
 - Use `@raise` to document exceptions
-- **Omit descriptions that just repeat the code** - if the method name and signature make it obvious, only include `@param`, `@return`, and `@raise` tags without a description
+- **Omit descriptions that just repeat the code** — if the method name and signature make it obvious, only include `@param`, `@return`, and `@raise` tags without a description
 
 ```ruby
-# Good - blank line before @param
 # Calculates the checksum for this identifier.
 #
-# @param value [String] the value to calculate
-# @return [Integer] the calculated checksum
-def calculate_checksum(value)
-end
-
-# Bad - no blank line
-# Calculates the checksum for this identifier.
 # @param value [String] the value to calculate
 # @return [Integer] the calculated checksum
 def calculate_checksum(value)
@@ -410,16 +177,8 @@ end
 
 ## Community Standards
 
-The repository includes GitHub community standards files:
-
-- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1; enforcement contact: `leonid@svyatov.com`
-- **`CONTRIBUTING.md`** — development setup, code style, commit conventions, and PR process
-- **`SECURITY.md`** — vulnerability reporting via GitHub Security Advisories; v5.x supported
-- **`.github/ISSUE_TEMPLATE/bug_report.md`** — bug report template (version, reproduction steps, expected vs actual)
-- **`.github/ISSUE_TEMPLATE/feature_request.md`** — feature request template (problem, solution, alternatives)
-- **`.github/pull_request_template.md`** — PR checklist (tests, RuboCop, changelog, docs, commit format)
-
-When creating issues or PRs, follow the templates. Commit messages must use Conventional Commits (see Commit Message Convention section).
+When creating issues or PRs, follow the templates in `.github/`. Commit messages must use
+Conventional Commits (see above). Code of Conduct enforcement contact: `leonid@svyatov.com`.
 
 ## Pre-Commit Checklist
 
@@ -433,27 +192,8 @@ Before committing changes, always verify these files are updated to accurately r
 
 ## Releasing a New Version
 
-This project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html):
-- **MAJOR** — breaking changes (incompatible API changes)
-- **MINOR** — new features (backwards-compatible)
-- **PATCH** — bug fixes (backwards-compatible)
+See the `release` skill (`.claude/skills/release/SKILL.md`) for the full procedure.
 
-1. Update `lib/sec_id/version.rb` with the new version number
-2. Update `CHANGELOG.md`: change `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD` and add new empty `[Unreleased]` section
-3. Update `README.md` installation version if needed (e.g., `~> 4.3` to `~> 4.4`)
-4. Run `bundle exec rake lock:refresh` — the committed lockfiles record `sec_id` as a path
-   gem at its current version, and CI installs frozen, so a stale lock fails every job
-5. Commit changes and open a PR: `main` requires a change request, so the bump cannot be pushed directly
-6. After merging, tag the merge commit: `git tag -a vX.Y.Z -m "Version X.Y.Z"` (signed automatically via `tag.gpgSign`) and `git push origin vX.Y.Z`
-7. Approve the `release` deployment when GitHub asks. The tag push starts `.github/workflows/release.yml`, which tests, builds, verifies the tag matches `SecID::VERSION`, and then waits for a reviewer before anything reaches RubyGems.org
-8. Create GitHub release at https://github.com/svyatov/sec_id/releases, pasting the CHANGELOG section for this version verbatim
-9. Verify the release:
-
-   ```bash
-   git tag -v vX.Y.Z                                                  # signature
-   curl -s https://rubygems.org/api/v1/attestations/sec_id-X.Y.Z.json # non-empty array
-   ```
-
-There is no local publish path. `rake release` is deliberately absent (see the `Rakefile` header);
-publishing runs only in CI, authenticated through RubyGems trusted publishing, so no API key exists
-on any machine.
+**There is no local publish path.** `rake release` is deliberately absent (see the `Rakefile`
+header); publishing runs only in CI through RubyGems trusted publishing, so no API key exists on
+any machine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,18 @@
 
 Thank you for your interest in contributing! This guide will help you get started.
 
-## Code of Conduct
+## Code of conduct
 
 This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
 
-## Development Setup
+## Development setup
 
 1. Fork and clone the repository
 2. Run `bin/setup` to install dependencies
 3. Run `bundle exec rake` to verify tests and linting pass
 4. Use `bin/console` for an interactive prompt to experiment
 
-## Running Tests and Linting
+## Running tests and linting
 
 ```bash
 bundle exec rake          # Run RuboCop, RBS validation, and RSpec (recommended)
@@ -22,15 +22,15 @@ bundle exec rubocop       # Run linter only
 bundle exec rubocop -a    # Auto-fix safe lint issues
 ```
 
-## Code Style
+## Code style
 
 - **Ruby 3.2+** required
 - **Max line length:** 120 characters
-- **RuboCop** with `rubocop-rspec` extension — run `bundle exec rubocop` before committing
+- **RuboCop** with `rubocop-rspec` extension, run `bundle exec rubocop` before committing
 - **RSpec** with `expect` syntax only (no monkey patching)
 - Follow the **Stepdown Rule**: callers before callees, high-level methods first
 
-## Commit Convention
+## Commit convention
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
@@ -57,48 +57,46 @@ fix: correct CUSIP checksum for alphanumeric input
 docs: update README with LEI usage examples
 ```
 
-## Pull Request Process
+## Pull request process
 
 1. **Fork** the repository and create a feature branch from `main`
 2. **Write tests** for any new functionality
 3. **Run `bundle exec rake`** to ensure all tests pass and RuboCop is clean
 4. **Update documentation** as needed:
-   - `CHANGELOG.md` — add an entry under `[Unreleased]`
-   - `README.md` — update usage examples if the public API changed
+   - `CHANGELOG.md`: add an entry under `[Unreleased]`
+   - `README.md`: update usage examples if the public API changed
 5. **Commit** using Conventional Commits format
 6. **Push** your branch and open a Pull Request
 
-## What Makes a Good Contribution
+## What makes a good contribution
 
-### Bug Reports
+### Bug reports
 
 - Include the SecID version, Ruby version, and OS
 - Provide a minimal code snippet that reproduces the issue
 - Describe expected vs actual behavior
 
-### Feature Requests
+### Feature requests
 
 - Explain the problem you're trying to solve
 - Describe your proposed solution
 - Consider alternatives you've evaluated
 
-### Code Contributions
+### Code contributions
 
-- Keep changes focused — one feature or fix per PR
+- Keep changes focused: one feature or fix per PR
 - Add tests for new functionality
 - Follow existing code patterns and conventions
-- Update YARD documentation for the public API — 100% coverage is enforced in CI (`bundle exec rake yard:stats`)
+- Update YARD documentation for the public API. 100% coverage is enforced in CI (`bundle exec rake yard:stats`)
 
 ## Governance
 
-SecID has one maintainer, [Leonid Svyatov](https://github.com/svyatov), who reviews and merges every
-change and publishes every release. Decisions are theirs. There is no steering group, no vote, and no
-second person who can merge.
+SecID has one maintainer, [Leonid Svyatov](https://github.com/svyatov). They review and merge every
+change, and they publish every release. There is no steering group, no vote, and no second person who
+can merge.
 
 No succession is arranged. If the maintainer stops, the project stops with them. The MIT license lets
-anyone fork and continue from the last published state, and that is the intended fallback rather than
-an oversight. This is stated plainly so you can weigh it before depending on the gem or investing in a
-contribution.
+anyone fork and continue from the last published state, and that is the intended fallback.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,27 @@
-# SecID [![Gem Version](https://badge.fury.io/rb/sec_id.svg)](https://rubygems.org/gems/sec_id) [![CI](https://github.com/svyatov/sec_id/actions/workflows/main.yml/badge.svg)](https://github.com/svyatov/sec_id/actions/workflows/main.yml) [![codecov](https://codecov.io/gh/svyatov/sec_id/graph/badge.svg?token=VV49EMQIIC)](https://codecov.io/gh/svyatov/sec_id) [![Documentation](https://img.shields.io/badge/docs-rubydoc.info-blue.svg)](https://rubydoc.info/gems/sec_id) [![Ruby](https://img.shields.io/badge/ruby-%3E%3D%203.2-CC342D.svg)](https://www.ruby-lang.org) [![Types: RBS](https://img.shields.io/badge/types-RBS-8A2BE2.svg)](https://github.com/svyatov/sec_id/tree/main/sig)
+# SecID
 
-> A Ruby toolkit for securities identifiers — validate, parse, normalize, detect, convert, generate, classify, and repair.
+A Ruby toolkit for securities identifiers: validate, parse, normalize, detect, convert, generate, classify, and repair.
 
-## Table of Contents
+[![Gem Version](https://badge.fury.io/rb/sec_id.svg)](https://rubygems.org/gems/sec_id) [![CI](https://github.com/svyatov/sec_id/actions/workflows/main.yml/badge.svg)](https://github.com/svyatov/sec_id/actions/workflows/main.yml) [![codecov](https://codecov.io/gh/svyatov/sec_id/graph/badge.svg?token=VV49EMQIIC)](https://codecov.io/gh/svyatov/sec_id) [![Documentation](https://img.shields.io/badge/docs-rubydoc.info-blue.svg)](https://rubydoc.info/gems/sec_id) [![Ruby](https://img.shields.io/badge/ruby-%3E%3D%203.2-CC342D.svg)](https://www.ruby-lang.org) [![Types: RBS](https://img.shields.io/badge/types-RBS-8A2BE2.svg)](https://github.com/svyatov/sec_id/tree/main/sig)
 
-- [Supported Ruby Versions](#supported-ruby-versions)
+- **Nothing to call, nothing to sign up for.** SecID validates all 16 identifier standards offline. No registry lookup, no API key, no network call anywhere in [`lib/`](lib/).
+- **9 of the 16 carry a checksum.** SecID validates it, restores a missing one, and repairs a wrong one.
+- **Zero runtime dependencies.** Runs on Ruby 3.2 or newer.
+- **Rails, if you want it.** An opt-in ActiveModel validator adds `validates :isin, sec_id: true`. It stays off the default require path, so the dependency count stays at zero.
+- **Typed.** Ships RBS signatures for the whole public API, checked by Steep in strict mode.
+
+## Table of contents
+
+- [Supported Ruby versions](#supported-ruby-versions)
 - [Installation](#installation)
-- [Supported Standards and Usage](#supported-standards-and-usage)
-  - [Metadata Registry](#metadata-registry) - enumerate, filter, look up, and detect identifier types
-  - [Text Scanning](#text-scanning) - find identifiers in freeform text
-  - [Debugging Detection](#debugging-detection) - understand why strings match or don't
-  - [Structured Validation](#structured-validation) - detailed error codes and messages
-  - [Pattern Matching](#pattern-matching) - destructure identifiers with `case/in`
-  - [Generating Test Fixtures](#generating-test-fixtures) - produce valid identifiers for tests
-  - [Repairing Typos](#repairing-typos) - suggest corrections for checksum-failing identifiers
+- [Supported standards and usage](#supported-standards-and-usage)
+  - [Metadata registry](#metadata-registry) - enumerate, filter, look up, and detect identifier types
+  - [Text scanning](#text-scanning) - find identifiers in freeform text
+  - [Debugging detection](#debugging-detection) - understand why strings match or don't
+  - [Structured validation](#structured-validation) - detailed error codes and messages
+  - [Pattern matching](#pattern-matching) - destructure identifiers with `case/in`
+  - [Generating test fixtures](#generating-test-fixtures) - produce valid identifiers for tests
+  - [Repairing typos](#repairing-typos) - suggest corrections for checksum-failing identifiers
   - [ISIN](#isin) - International Securities Identification Number
   - [CUSIP](#cusip) - Committee on Uniform Securities Identification Procedures
   - [CEI](#cei) - CUSIP Entity Identifier
@@ -30,16 +38,17 @@
   - [BIC](#bic) - Business Identifier Code / SWIFT code
   - [DTI](#dti) - Digital Token Identifier
   - [UPI](#upi) - Unique Product Identifier
-- [ActiveModel / Rails Validator](#activemodel--rails-validator) - declarative `validates :isin, sec_id: {...}`
-- [Lookup Service Integration](#lookup-service-integration)
-- [Type Signatures (RBS)](#type-signatures-rbs)
+- [ActiveModel / Rails validator](#activemodel--rails-validator) - declarative `validates :isin, sec_id: {...}`
+- [Lookup service integration](#lookup-service-integration)
+- [Type signatures (RBS)](#type-signatures-rbs)
 - [Development](#development)
+- [Support and status](#support-and-status)
 - [Contributing](#contributing)
 - [Changelog](#changelog)
 - [Versioning](#versioning)
 - [License](#license)
 
-## Supported Ruby Versions
+## Supported Ruby versions
 
 Ruby 3.2+ is required.
 
@@ -65,7 +74,7 @@ gem install sec_id
 
 **Upgrading from v4?** See [MIGRATION.md](MIGRATION.md) for a step-by-step guide.
 
-## Supported Standards and Usage
+## Supported standards and usage
 
 All identifier classes provide `valid?`, `errors`, `validate`, `validate!` methods at both class and instance levels.
 
@@ -90,7 +99,7 @@ SecID::ISIN.new('INVALID').to_h
 #      valid: false, components: { country_code: nil, nsin: nil, checksum: nil } }
 ```
 
-**All identifiers** support value equality — two instances of the same type with the same normalized form are equal:
+**All identifiers** support value equality. Two instances of the same type with the same normalized form are equal:
 
 ```ruby
 a = SecID::ISIN.new('US5949181045')
@@ -109,7 +118,7 @@ Set.new([a, b]).size         # => 1
 - `restore!` / `.restore!` - restores checksum in place and returns `self` / instance
 - `checksum` / `calculate_checksum` - calculates and returns the checksum
 
-### Metadata Registry
+### Metadata registry
 
 All identifier classes are registered automatically and can be enumerated, filtered, and looked up by symbol key:
 
@@ -165,7 +174,7 @@ SecID.parse('514000', on_ambiguous: :all)          # => [#<SecID::WKN>, #<SecID:
 SecID.parse('US5949181045', on_ambiguous: :raise)  # => #<SecID::ISIN> (unambiguous, no error)
 ```
 
-### Text Scanning
+### Text scanning
 
 Find identifiers embedded in freeform text:
 
@@ -191,12 +200,12 @@ match.identifier.normalized  # => "US5949181045"
 
 > **Known limitations:** Format-only types (CIK, Valoren, WKN, BIC) can false-positive on
 > common numbers and short words in prose (a BIC8 is 8 letters with a valid country code in the
-> middle) — use the `types:` filter to restrict scanning when
+> middle). Use the `types:` filter to restrict scanning when
 > this is a concern. Identifiers prefixed with special characters (e.g. `#US5949181045`) may be
 > consumed as a single token by CUSIP's `*@#` character class and fail validation, preventing
 > the embedded identifier from being found.
 
-### Debugging Detection
+### Debugging detection
 
 Understand why a string matches or doesn't match specific identifier types:
 
@@ -210,7 +219,7 @@ isin[:errors].first[:error]       # => :invalid_checksum
 SecID.explain('US5949181045', types: %i[isin cusip])
 ```
 
-### Structured Validation
+### Structured validation
 
 All identifier classes provide a Rails-like `#errors` API for detailed error reporting:
 
@@ -266,7 +275,7 @@ SecID::FIGI.new('BSG000BLNNH6').validate!
 isin = SecID::ISIN.validate!('US5949181045')  # => #<SecID::ISIN>
 ```
 
-### Pattern Matching
+### Pattern matching
 
 Every identifier destructures in `case/in` via its parsed components. Since `SecID.parse` returns `nil` for
 anything invalid, an `in nil` branch is a complete validity guard:
@@ -306,11 +315,11 @@ CIK, WKN, and Valoren have no sub-fields: they match a bare `in SecID::CIK` but 
 
 Watch the `:type` key: on a `SecID::Match` it is the registry symbol (`:occ`), while on an `OCC` instance it is the
 OSI option type (`'C'` or `'P'`), so `in SecID::OCC[type: :occ]` never matches. Other types have no `:type` component
-at all — `#to_h`'s envelope keys (`:type`, `:full_id`, `:normalized`, `:valid`) are not part of the pattern surface.
+at all. `#to_h`'s envelope keys (`:type`, `:full_id`, `:normalized`, `:valid`) are not part of the pattern surface.
 
-### Generating Test Fixtures
+### Generating test fixtures
 
-Generate syntactically valid identifiers — with correct checksum where applicable — for use as test fixtures. Available per class and via the central dispatcher:
+Generate syntactically valid identifiers, with correct checksum where applicable, for use as test fixtures. Available per class and via the central dispatcher:
 
 ```ruby
 SecID::ISIN.generate          # => #<SecID::ISIN ...>
@@ -324,17 +333,17 @@ SecID.generate(:nope)         # => raises ArgumentError: Unknown identifier type
 SecID::LEI.generate(random: Random.new(42)) == SecID::LEI.generate(random: Random.new(42))  # => true
 ```
 
-> **Generated identifiers are valid in format only — they are not real, registered securities.**
+> **Generated identifiers are valid in format only. They are not real, registered securities.**
 > Country codes, FIGI prefixes, OCC expiry dates, and CFI category/group/attribute choices are
 > randomly selected (from the values each standard permits) and do not map to real-world
 > instruments. Use them as test fixtures, not as references to actual securities.
 
-### Repairing Typos
+### Repairing typos
 
-Turn the checksum from a gatekeeper into a repair engine. For a checksum-**failing** identifier, `suggest` enumerates the plausible single-character human errors — visual/OCR homoglyph substitutions (`O`↔`0`, `I`↔`1`, `5`↔`S`, `8`↔`B`, …) and adjacent transpositions — keeps only the edits that re-validate, and returns them as confidence-ranked `SecID::Suggestion` candidates that report *what changed*. Available for all 9 checksum types (ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CEI, DTI, UPI) per class and via the central dispatcher:
+Turn the checksum from a gatekeeper into a repair engine. For a checksum-**failing** identifier, `suggest` enumerates the plausible single-character human errors (visual/OCR homoglyph substitutions such as `O`↔`0`, `I`↔`1`, `5`↔`S`, `8`↔`B`, plus adjacent transpositions), keeps only the edits that re-validate, and returns them as confidence-ranked `SecID::Suggestion` candidates that report *what changed*. Available for all 9 checksum types (ISIN, CUSIP, SEDOL, FIGI, LEI, IBAN, CEI, DTI, UPI) per class and via the central dispatcher:
 
 ```ruby
-# A letter O typed where a 0 belongs — 'US5949181O45' should be 'US5949181045'
+# A letter O typed where a 0 belongs: 'US5949181O45' should be 'US5949181045'
 top = SecID::ISIN.suggest('US5949181O45').first
 top.to_s          # => 'US5949181045'  (the corrected identifier)
 top.edit          # => :substitution
@@ -342,28 +351,28 @@ top.position      # => 9
 top.from          # => 'O'
 top.to            # => '0'
 top.confidence    # => :high
-top.identifier    # => #<SecID::ISIN ...>  (parsed and valid — call .country_code, .to_h, etc.)
+top.identifier    # => #<SecID::ISIN ...>  (parsed and valid; call .country_code, .to_h, etc.)
 
 # Module-level: infers every format-compatible checksum type (like parse / detect)
 SecID.suggest('US5949181O45')                   # => [#<SecID::Suggestion type=:isin ...>, ...]
 SecID.suggest('US5949181O45', types: [:isin])   # => restrict to specific types
 ```
 
-Each candidate carries the corrected `identifier` (a parsed, valid instance), the `edit` kind, its `position`, the `from`/`to` characters, and a `confidence` tier. Candidates are ranked by confidence: `:high` homoglyph substitutions first, then `:medium` adjacent transpositions, then the `:checksum` recompute (body assumed correct, wrong check character) last as a fallback hypothesis. **There is no `:low` tier** — coincidental substitutions that merely satisfy the checksum are never generated, keeping the result small and high-precision.
+Each candidate carries the corrected `identifier` (a parsed, valid instance), the `edit` kind, its `position`, the `from`/`to` characters, and a `confidence` tier. Candidates are ranked by confidence: `:high` homoglyph substitutions first, then `:medium` adjacent transpositions, then the `:checksum` recompute (body assumed correct, wrong check character) last as a fallback hypothesis. **There is no `:low` tier.** Coincidental substitutions that merely satisfy the checksum are never generated, keeping the result small and high-precision.
 
 > **`suggest` returns candidates, never authoritative corrections, and never mutates its input.**
-> Every returned candidate fully re-validates (`valid?` is the oracle), so no checksum-invalid candidate escapes —
+> Every returned candidate fully re-validates (`valid?` is the oracle), so no checksum-invalid candidate escapes,
 > but a valid candidate is not necessarily *the* correction, so the `confidence` tier is how *you* decide what to
 > trust. This matters for financial identifiers.
 
 Notes and limitations:
 
-- **Never empty for structurally-valid input** — a parseable but checksum-failing identifier always yields at least the `:checksum` fallback. Only wrong-length or illegal-charset input (which fails the format gate), or an already-valid identifier (nothing to repair), returns `[]`.
-- **Vowel-free reachability** — SEDOL, FIGI, DTI, and UPI exclude vowels from their charset, so an `O`-for-`0` or `I`-for-`1` typo is unparseable and therefore unrepairable (it fails the format gate before enumeration). The mistyped character must be *in* the type's charset to be reachable.
-- **Single body error only** — two or more wrong body characters, or a dropped/doubled character (insertion/deletion), are out of scope; such input returns only the `:checksum` fallback, never additional body candidates.
-- **Non-checksum types are unsupported** — CIK, OCC, WKN, Valoren, CFI, FISN, and BIC have no checksum oracle, so they have no `suggest`; `SecID.suggest` silently skips them.
+- **Never empty for structurally-valid input.** A parseable but checksum-failing identifier always yields at least the `:checksum` fallback. Only wrong-length or illegal-charset input (which fails the format gate), or an already-valid identifier (nothing to repair), returns `[]`.
+- **Vowel-free reachability.** SEDOL, FIGI, DTI, and UPI exclude vowels from their charset, so an `O`-for-`0` or `I`-for-`1` typo is unparseable and therefore unrepairable (it fails the format gate before enumeration). The mistyped character must be *in* the type's charset to be reachable.
+- **Single body error only.** Two or more wrong body characters, or a dropped/doubled character (insertion/deletion), are out of scope; such input returns only the `:checksum` fallback, never additional body candidates.
+- **Non-checksum types are unsupported.** CIK, OCC, WKN, Valoren, CFI, FISN, and BIC have no checksum oracle, so they have no `suggest`; `SecID.suggest` silently skips them.
 
-**Precision** (simulated over 1,000 seeded samples per checksum type — see [`benchmark/suggest_precision.rb`](benchmark/suggest_precision.rb)): every reachable, single-error homoglyph or transposition that yields a checksum-failing identifier is recovered — the correct identifier is **always** among the returned candidates (100%), and is the top-ranked body candidate ~89% of the time for homoglyph errors. In-charset homoglyph reachability averages ~96% (100% for the letter-permitting types, lower for the four vowel-free ones).
+**Precision** (simulated over 1,000 seeded samples per checksum type; see [`benchmark/suggest_precision.rb`](benchmark/suggest_precision.rb)): every reachable, single-error homoglyph or transposition that yields a checksum-failing identifier is recovered: the correct identifier is **always** among the returned candidates (100%), and is the top-ranked body candidate ~89% of the time for homoglyph errors. In-charset homoglyph reachability averages ~96% (100% for the letter-permitting types, lower for the four vowel-free ones).
 
 ### ISIN
 
@@ -703,7 +712,7 @@ SecID::CFI.new('QQXXXX').decode     # => nil (decode returns nil for an invalid 
 
 CFI is validated strictly against the ISO 10962:2021 code tables for all 14 categories: the category (position 1), the group (position 2), and every attribute (positions 3-6) must be a value the standard defines for that group. `X` means "not applicable" and is accepted in every position; `Strategies` (`K`) codes carry no attributes and require `XXXX`. An impermissible attribute letter raises `InvalidStructureError` (`:invalid_attribute`).
 
-> **Migration from &lt; 6.0:** the old category-wide equity predicates (`cfi.voting?`, `cfi.fully_paid?`, …) are removed. Use `cfi.decode` and its scoped fields instead — a predicate now lives on the field whose domain defines it: `cfi.voting?` → `cfi.decode.attributes.voting_right.voting?`. Two do not map name-for-name: `cfi.equity?` → `cfi.decode.category.equity?` (or `cfi.category == :equity`), and `cfi.no_restrictions?` → `cfi.decode.attributes.ownership_restrictions.free_of_restrictions?`. Several group letters and symbols also changed to match ISO 10962:2021 (e.g. non-listed options `H` are now classified by underlying, and `LS` → `:securities_lending`, `TI` → `:indices`).
+> **Migration from &lt; 6.0:** the old category-wide equity predicates (`cfi.voting?`, `cfi.fully_paid?`, …) are removed. Use `cfi.decode` and its scoped fields instead. A predicate now lives on the field whose domain defines it: `cfi.voting?` → `cfi.decode.attributes.voting_right.voting?`. Two do not map name-for-name: `cfi.equity?` → `cfi.decode.category.equity?` (or `cfi.category == :equity`), and `cfi.no_restrictions?` → `cfi.decode.attributes.ownership_restrictions.free_of_restrictions?`. Several group letters and symbols also changed to match ISO 10962:2021 (e.g. non-listed options `H` are now classified by underlying, and `LS` → `:securities_lending`, `TI` → `:indices`).
 
 ```ruby
 # Introspect valid codes
@@ -758,7 +767,7 @@ SecID::BIC.valid?('DEUTZZFF')       # => false ('ZZ' is not a recognized country
 SecID::BIC.countries                # => ['AD', 'AE', 'AF', ...] (sorted, includes 'XK')
 ```
 
-BIC validation confirms structure and a real country code only. It does **not** verify that the institution, location, or branch corresponds to a registered SWIFT participant — that requires the licensed SWIFT registry.
+BIC validation confirms structure and a real country code only. It does **not** verify that the institution, location, or branch corresponds to a registered SWIFT participant. That requires the licensed SWIFT registry.
 
 ### DTI
 
@@ -782,7 +791,7 @@ dti.restore!                # => #<SecID::DTI> (mutates instance)
 dti.calculate_checksum  # => 'S'
 ```
 
-DTI accepts exactly 9 characters: an 8-character base (first character never `0`) plus 1 check character, both drawn from a 30-symbol alphabet — digits `0`-`9` and consonants (vowels and `Y` never appear). Unlike most checksum types in this gem, `checksum` and `calculate_checksum` return a `String`, not an `Integer` (as does UPI). The check character is computed fully offline via ISO 7064 hybrid MOD 31,30 — no registry lookup or paywalled ISO 24165-1 spec required.
+DTI accepts exactly 9 characters: an 8-character base (first character never `0`) plus 1 check character, both drawn from a 30-symbol alphabet: digits `0`-`9` and consonants (vowels and `Y` never appear). Unlike most checksum types in this gem, `checksum` and `calculate_checksum` return a `String`, not an `Integer` (as does UPI). The check character is computed fully offline via ISO 7064 hybrid MOD 31,30, with no registry lookup or paywalled ISO 24165-1 spec required.
 
 > **Grandfathered code:** Bitcoin's registered code (`4H95J0R2X`) predates the algorithm and fails the MOD 31,30 computation (which yields `4H95J0R2T`). A frozen exception map honors the registry's assignment across `valid?`, `restore`, and `checksum` alike:
 >
@@ -813,15 +822,15 @@ upi.restore!               # => #<SecID::UPI> (mutates instance)
 upi.calculate_checksum  # => '2'
 ```
 
-UPI accepts exactly 12 characters: a fixed `QZ` prefix, a 9-character body, and 1 check character, all drawn from the same 30-symbol alphabet as DTI — digits `0`-`9` and consonants (vowels and `Y` never appear). Like DTI, `checksum` and `calculate_checksum` return a `String`, not an `Integer`. The check character is computed fully offline via ISO 7064 hybrid MOD 31,30 over the 11 preceding characters — no DSB registry lookup or paywalled ISO 4914 spec required.
+UPI accepts exactly 12 characters: a fixed `QZ` prefix, a 9-character body, and 1 check character, all drawn from the same 30-symbol alphabet as DTI: digits `0`-`9` and consonants (vowels and `Y` never appear). Like DTI, `checksum` and `calculate_checksum` return a `String`, not an `Integer`. The check character is computed fully offline via ISO 7064 hybrid MOD 31,30 over the 11 preceding characters, with no DSB registry lookup or paywalled ISO 4914 spec required.
 
-> **Coexistence with ISIN:** a UPI shares the 12-character length bucket with ISIN. A UPI whose digit check character also satisfies ISIN's Luhn detects as both (`SecID.detect('QZXKR05S3DL1') # => [:isin, :upi]`), with ISIN ranked first; `SecID.parse(..., on_ambiguous: :raise)` surfaces the collision. UPI validation itself is fully offline and existence is **not** verified — that requires the licensed DSB registry.
+> **Coexistence with ISIN:** a UPI shares the 12-character length bucket with ISIN. A UPI whose digit check character also satisfies ISIN's Luhn detects as both (`SecID.detect('QZXKR05S3DL1') # => [:isin, :upi]`), with ISIN ranked first; `SecID.parse(..., on_ambiguous: :raise)` surfaces the collision. UPI validation itself is fully offline and existence is **not** verified. That requires the licensed DSB registry.
 
-## ActiveModel / Rails Validator
+## ActiveModel / Rails validator
 
-SecID ships an opt-in [ActiveModel](https://api.rubyonrails.org/classes/ActiveModel/Validations.html) validator, registered as `sec_id`, for declarative validation of any supported identifier type. It adds **no runtime dependency** — `require 'sec_id'` loads none of it, and ActiveModel is a development/test dependency only.
+SecID ships an opt-in [ActiveModel](https://api.rubyonrails.org/classes/ActiveModel/Validations.html) validator, registered as `sec_id`, for declarative validation of any supported identifier type. It adds **no runtime dependency**: `require 'sec_id'` loads none of it, and ActiveModel is a development/test dependency only.
 
-**In Rails it just works.** A Railtie loads the validator automatically after the framework boots, so `gem 'sec_id'` in your `Gemfile` is enough — no `require:` option and no initializer:
+**In Rails it just works.** A Railtie loads the validator automatically after the framework boots, so `gem 'sec_id'` in your `Gemfile` is enough, with no `require:` option and no initializer:
 
 ```ruby
 class Security < ApplicationRecord
@@ -838,13 +847,13 @@ require 'sec_id/active_model'
 ### Validation modes
 
 ```ruby
-# Single type — the value must be a valid ISIN
+# Single type: the value must be a valid ISIN
 validates :isin, sec_id: { type: :isin }
 
-# Allowlist — valid as at least one of the listed types
+# Allowlist: valid as at least one of the listed types
 validates :ref, sec_id: { types: %i[isin cusip] }
 
-# Type-agnostic — valid as any supported type
+# Type-agnostic: valid as any supported type
 validates :ref, sec_id: true
 ```
 
@@ -863,16 +872,16 @@ With `normalize: true` in allowlist or agnostic mode, a value valid as more than
 
 ### Error messages and `details:`
 
-On failure the validator adds one error under the `:sec_id` key with a type-aware default ("is not a valid ISIN" for a single type, "is not a valid securities identifier" for an allowlist/agnostic). Override the message in either of two ways: pass the standard `message:` option (the simplest, per-validation override), or define the attribute-scoped i18n key `activemodel.errors.models.<model>.attributes.<attribute>.sec_id` in your locale files. (The generic `activemodel.errors.messages.sec_id` key is not consulted, because the built-in default is supplied as ActiveModel's `message:` fallback.) Pass `details: true` (with a single `type:` — it is ignored for an allowlist/agnostic) to surface sec_id's specific reason instead of the generic text:
+On failure the validator adds one error under the `:sec_id` key with a type-aware default ("is not a valid ISIN" for a single type, "is not a valid securities identifier" for an allowlist/agnostic). Override the message in either of two ways: pass the standard `message:` option (the simplest, per-validation override), or define the attribute-scoped i18n key `activemodel.errors.models.<model>.attributes.<attribute>.sec_id` in your locale files. (The generic `activemodel.errors.messages.sec_id` key is not consulted, because the built-in default is supplied as ActiveModel's `message:` fallback.) Pass `details: true` (with a single `type:`; it is ignored for an allowlist/agnostic) to surface sec_id's specific reason instead of the generic text:
 
 ```ruby
 validates :isin, sec_id: { type: :isin, details: true }
 # a bad checksum reports e.g. "Checksum '4' is invalid, expected '5'"
 ```
 
-Standard `EachValidator` options — `allow_nil`, `allow_blank`, `if`, `unless`, `on` — work as usual. Tested against Rails 7.2, 8.0, and 8.1.
+Standard `EachValidator` options (`allow_nil`, `allow_blank`, `if`, `unless`, `on`) work as usual. Tested against Rails 7.2, 8.0, and 8.1.
 
-## Lookup Service Integration
+## Lookup service integration
 
 SecID validates identifiers but does not include HTTP clients. The [`docs/guides/`](docs/guides/) directory provides integration patterns for external lookup services using only stdlib (`net/http`, `json`):
 
@@ -885,10 +894,10 @@ SecID validates identifiers but does not include HTTP clients. The [`docs/guides
 
 Each guide includes a complete adapter class and a [runnable example](examples/).
 
-## Type Signatures (RBS)
+## Type signatures (RBS)
 
 sec_id ships hand-written [RBS](https://github.com/ruby/rbs) signatures under `sig/`,
-packaged in the gem — so if you use [Steep](https://github.com/soutaro/steep) or an
+packaged in the gem, so if you use [Steep](https://github.com/soutaro/steep) or an
 RBS-aware editor, sec_id's types resolve automatically on install, no `rbs collection`
 entry required. The only standard-library signature referenced is `date`, declared in
 `sig/manifest.yaml`.
@@ -914,10 +923,19 @@ committed signatures fall out of sync with the tables.
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies.
-Then, run `bundle exec rake` to run the tests. You can also run `bin/console`
-for an interactive prompt that will allow you to experiment.
+Then run `bundle exec rake` to run RuboCop, validate the RBS signatures, and run the specs.
+`bin/console` gives you an interactive prompt to experiment in.
 
-To install this gem onto your local machine, run `bundle exec rake install`.
+To use your working copy from another project, point its Gemfile at the checkout:
+`gem 'sec_id', path: '/path/to/sec_id'`.
+
+Releases are published from CI by pushing a tag, so there is no local publish task.
+
+## Support and status
+
+Ask questions in [Discussions](https://github.com/svyatov/sec_id/discussions). Report bugs in the [issue tracker](https://github.com/svyatov/sec_id/issues). Both are public and searchable, so the next reader with your question finds the answer.
+
+One person actively maintains SecID. They read bug reports and pull requests, and they track each identifier standard against its published specification. No response time is promised. See [Governance](CONTRIBUTING.md#governance) for who decides and what happens if they stop.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,27 +1,27 @@
-# Security Policy
+# Security policy
 
-## Supported Versions
+## Supported versions
 
 | Version | Supported |
 |---------|-----------|
 | 7.x     | Yes       |
 | < 7.0   | No        |
 
-Fixes land on the current major only. Older majors receive no backports.
+Fixes land on the current major only.
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
 If you discover a security vulnerability in SecID, please report it through [GitHub Security Advisories](https://github.com/svyatov/sec_id/security/advisories/new).
 
 **Do not** open a public issue for security vulnerabilities.
 
-## What to Expect
+## What to expect
 
 - **Acknowledgment** within 48 hours of your report
 - **Initial assessment** within 1 week
 - **Fix and disclosure** coordinated with you before public release
 
-## Disclosure Policy
+## Disclosure policy
 
 We follow coordinated disclosure. Once a fix is released, we will:
 

--- a/docs/guides/eurex.md
+++ b/docs/guides/eurex.md
@@ -1,8 +1,8 @@
-# Eurex Reference Data API Integration
+# Eurex reference data API integration
 
 Look up Eurex-listed derivative products by ISIN using the [Eurex Reference Data GraphQL API](https://www.eurex.com/ex-en/data/free-reference-data-api).
 
-## Service Overview
+## Service overview
 
 Eurex provides free reference data for its listed derivatives via a GraphQL API. The API covers products, contracts, trading hours, and expirations. Use it to look up derivative product metadata by ISIN, product code, or name.
 
@@ -123,7 +123,7 @@ result[:products].each do |prod|
 end
 ```
 
-## Available Queries
+## Available queries
 
 The GraphQL API supports several root queries beyond `ProductInfos`:
 
@@ -153,7 +153,7 @@ query {
 }
 ```
 
-## Rate Limiting
+## Rate limiting
 
 The shared API key has undisclosed rate limits. For production use, register a dedicated key. The API does not return rate-limit headers.
 
@@ -170,7 +170,7 @@ sleep 1.0
 - **Contract data** (settlement prices): cache for 1 hour (updates daily)
 - **Trading hours/holidays:** cache for 24 hours
 
-## Error Handling
+## Error handling
 
 | Scenario | Response |
 |---|---|
@@ -189,6 +189,6 @@ GraphQL errors are returned in the response body even with HTTP 200:
 }
 ```
 
-## Runnable Example
+## Runnable example
 
 See [`examples/eurex_lookup.rb`](../../examples/eurex_lookup.rb) for a self-contained script.

--- a/docs/guides/gleif.md
+++ b/docs/guides/gleif.md
@@ -1,8 +1,8 @@
-# GLEIF API Integration
+# GLEIF API integration
 
 Look up legal entities by LEI using the [GLEIF API](https://www.gleif.org/en/lei-data/gleif-api).
 
-## Service Overview
+## Service overview
 
 The Global Legal Entity Identifier Foundation (GLEIF) provides free access to LEI data. The API returns entity registration details, legal names, addresses, and relationship data for any valid LEI.
 
@@ -114,7 +114,7 @@ puts "#{result[:name]} (#{result[:jurisdiction]})"
 puts "Status: #{result[:status]}"
 ```
 
-## Rate Limiting
+## Rate limiting
 
 GLEIF allows approximately **60 requests per minute**. The API returns HTTP 429 when exceeded.
 
@@ -133,7 +133,7 @@ sleep 1.0
 
 LEI registrations are renewed annually, so data is relatively stable.
 
-## Error Handling
+## Error handling
 
 | Scenario | Response |
 |---|---|
@@ -156,6 +156,6 @@ The GLEIF API uses [JSON:API](https://jsonapi.org/) format. Errors are returned 
 }
 ```
 
-## Runnable Example
+## Runnable example
 
 See [`examples/gleif_lookup.rb`](../../examples/gleif_lookup.rb) for a self-contained script.

--- a/docs/guides/openfigi.md
+++ b/docs/guides/openfigi.md
@@ -1,8 +1,8 @@
-# OpenFIGI API Integration
+# OpenFIGI API integration
 
 Look up financial instruments by FIGI using the [OpenFIGI API](https://www.openfigi.com/api).
 
-## Service Overview
+## Service overview
 
 OpenFIGI provides free mapping between Financial Instrument Global Identifiers (FIGIs) and other market identifiers. The API maps FIGIs to instrument metadata including ticker, exchange, security type, and market sector.
 
@@ -121,7 +121,7 @@ body = [{ idType: 'ID_CUSIP', idValue: '594918104' }]
 body = [{ idType: 'TICKER', idValue: 'MSFT', exchCode: 'US' }]
 ```
 
-## Rate Limiting
+## Rate limiting
 
 | | Without API Key | With API Key |
 |---|---|---|
@@ -162,7 +162,7 @@ def cached_lookup(figi_str)
 end
 ```
 
-## Error Handling
+## Error handling
 
 | Scenario | Response |
 |---|---|
@@ -176,6 +176,6 @@ end
 
 Note that a 200 response can still contain per-job errors. Always check each result element for `"error"` or `"warning"` keys.
 
-## Runnable Example
+## Runnable example
 
 See [`examples/openfigi_lookup.rb`](../../examples/openfigi_lookup.rb) for a self-contained script.

--- a/docs/guides/sec-edgar.md
+++ b/docs/guides/sec-edgar.md
@@ -1,8 +1,8 @@
-# SEC EDGAR API Integration
+# SEC EDGAR API integration
 
 Look up SEC filing entities by CIK using the [SEC EDGAR API](https://www.sec.gov/edgar/sec-api-documentation).
 
-## Service Overview
+## Service overview
 
 SEC EDGAR (Electronic Data Gathering, Analysis, and Retrieval) provides free access to company filings, ownership data, and entity information. The submissions endpoint returns entity metadata and recent filings for a given CIK.
 
@@ -106,7 +106,7 @@ Validate and normalize with SecID before calling the API. `SecID::CIK#normalized
 ```ruby
 adapter = SecEdgarAdapter.new(user_agent: 'MyApp admin@example.com')
 
-# validate! accepts any CIK format — with or without leading zeros
+# validate! accepts any CIK format, with or without leading zeros
 cik = SecID::CIK.validate!('1521365')
 cik.normalized  # => "0001521365"
 
@@ -116,7 +116,7 @@ puts result[:tickers]        # Trading tickers
 puts result[:recent_filings] # Last 5 filings
 ```
 
-## Rate Limiting
+## Rate limiting
 
 SEC EDGAR allows **10 requests per second**. Exceeding this results in temporary IP blocks.
 
@@ -135,7 +135,7 @@ For bulk lookups, consider downloading the [full company index](https://www.sec.
 - **Recent filings:** cache for 1 hour (new filings appear daily for active filers)
 - **Historical filings:** cache indefinitely (they don't change)
 
-## Error Handling
+## Error handling
 
 | Scenario | Response |
 |---|---|
@@ -146,6 +146,6 @@ For bulk lookups, consider downloading the [full company index](https://www.sec.
 
 SEC EDGAR may silently block your IP if you exceed rate limits without returning a 429. If requests start timing out, back off significantly.
 
-## Runnable Example
+## Runnable example
 
 See [`examples/sec_edgar_lookup.rb`](../../examples/sec_edgar_lookup.rb) for a self-contained script.

--- a/sec_id.gemspec
+++ b/sec_id.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Leonid Svyatov']
   spec.email         = ['leonid@svyatov.ru']
 
-  spec.summary       = 'A Ruby toolkit for securities identifiers — validate, parse, normalize, detect, convert, ' \
+  spec.summary       = 'A Ruby toolkit for securities identifiers: validate, parse, normalize, detect, convert, ' \
                        'generate, classify, and repair.'
   spec.description   = 'Validate, normalize, parse, convert, generate, classify, and repair securities identifiers. ' \
                        'Auto-detect identifier type from any string. Calculate and restore checksums. Suggest ' \


### PR DESCRIPTION
Closes R-DOC-08, R-DOC-09, R-DOC-10, and the non-CHANGELOG half of R-DOC-05.

## What a reader gets above the fold

The README opened with six badges wedged into the `#` heading, then a one-line tagline, then straight into the table of contents. A reader deciding between this gem and whatever they already use got no answer, and a reader wondering whether it is still alive got none either.

Now: bare `# SecID`, the tagline, the badge row, then five fact bullets before the first `##`.

R-DOC-10 needs one claim that names a boundary, a number, or a competitor, and that traces to something checkable. The lead bullet is **16 identifier standards validated offline, with no network call anywhere in `lib/`**. Both halves are verifiable without trusting the README: `ls lib/sec_id/*.rb` counts the types, and `net/http`, `open-uri`, and `socket` appear nowhere in `lib/`.

The other four cover scale (9 of the 16 carry a checksum), fit (zero runtime dependencies on Ruby 3.2+), the Rails adapter, and RBS.

The claim I did **not** ship is "the first offline DTI and UPI validator in any language." It is the strongest thing this gem can say, and it traces only to our own changelog. I could not verify "in any language," and an unverifiable superlative is exactly what R-DOC-10's evidence half exists to catch. Worth making somewhere it can be sourced.

## Support and status (R-DOC-08, R-DOC-09)

A new section before Contributing points questions at Discussions and defects at the issue tracker, both public and searchable, and states that one person maintains this with no promised response time. It links the governance section added in #176 rather than repeating it.

## The prose sweep (R-DOC-05)

Mechanical and large. Per file:

| File | Em dashes removed | Headings recased |
|---|---|---|
| `README.md` | 35 | 12 |
| `CONTRIBUTING.md` | 5 | 11 |
| `SECURITY.md` | 0 | 5 |
| `docs/guides/*.md` | 1 | 21 |

Each em dash was replaced by the punctuation that actually fits its job, a period, colon, semicolon, comma, or parentheses, never a spaced hyphen. No sentence changed meaning.

Every renamed heading moved its anchor, so the 35-entry table of contents was rebuilt. A script re-derives every heading slug and checks every `](#...)` link against it; zero broken anchors.

`CODE_OF_CONDUCT.md` keeps its Title Case headings under the rule's own carve-out for attributed third-party documents.

`MIGRATION.md` still carries 33 em dashes and is deliberately untouched: R-DOC-05's check names README, `docs/`, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, and CHANGELOG entry text, and MIGRATION is not among them.

## Two things found while reading

- The Development section told people to run `bundle exec rake install`. That task stopped existing in #175, when `bundler/gem_tasks` was removed with the local publish path. Replaced with the `path:` Gemfile line, which is what actually works.
- The gemspec summary and the README tagline differed by a dash. Both now read the same, and the forge description was updated to match.

## Verification

- `bundle exec rake` green
- Zero em dashes, en dashes, emoji, and banned adjectives across every file in R-DOC-05's scope
- Every README anchor resolves against the rewritten headings
- All new prose passed back through oss-writing, which caught passive voice in three bullets, two run-on sentences, a recap in SECURITY.md, and an invented contrast in the governance text