### PR TITLE
build: note the matrix lockfiles next to the updater that misses them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@
 
 version: 2
 updates:
+  # Dependabot refreshes Gemfile.lock only. It finds lockfiles by name, and
+  # `gemfiles/rails_8.0.gemfile.lock` is not a name it parses, so the three Rails matrix
+  # locks are left behind. Run `bundle exec rake lock:refresh` to relock all four.
+  #
+  # Only a changed requirement needs that. The matrix gemfiles eval the root Gemfile, so
+  # their locks record its requirement strings; a PR that edits one leaves them
+  # disagreeing, and the frozen install fails all four Rails jobs on the PR itself. A bump
+  # inside an unchanged requirement drifts silently and harmlessly. Red Rails jobs on an
+  # otherwise green Dependabot PR are the signal to relock.
   - package-ecosystem: "bundler" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
Follow-up to #173. Comment only, no behaviour change.

`rake lock:refresh` exists because Dependabot finds lockfiles by name, and `gemfiles/rails_8.0.gemfile.lock` is not a name it parses. That was documented in the `Rakefile`, above the task itself, which is not where anyone is standing when they merge a Dependabot PR.

The note also narrows the rule, because my first version of it overstated the risk. The matrix gemfiles `eval_gemfile` the root `Gemfile`, so their locks record its requirement strings:

```
  parallel (< 2)
  rbs (~> 4.0.3)
  rubocop (~> 1.88.0)
```

So a Dependabot PR that edits a requirement leaves the three matrix locks disagreeing with the Gemfile, and the frozen install fails all four Rails jobs on the PR itself. That case cannot be merged past unnoticed. What drifts silently is only a bump inside an unchanged requirement, where the matrix jobs keep testing a slightly older patch version and nothing breaks.

Red Rails jobs on an otherwise green Dependabot PR are the signal to relock. The comment says that, so this is a note about reading CI rather than a manual step to remember.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining how dependency lockfiles are refreshed.
  * Documented when manual lockfile updates are required and how CI indicates missing refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->