### PR TITLE
chore: bump version to 7.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ## [Unreleased]
 
+## [7.1.1] - 2026-07-31
+
+Documentation and packaging only. No identifier, checksum, or public method changed.
+
+This is the first release published from CI through RubyGems trusted publishing, signed with sigstore and pushed with a build provenance attestation.
+
+### Changed
+
+- README declares the public API that Semantic Versioning covers, names the `@api private` internals excluded from it, and links where to ask a question and where to report a defect
+- CHANGELOG version headings resolve to comparison links, and 2.0.1 has the entry it never had
+- Gem summary punctuation matches the README tagline
+
 ## [7.1.0] - 2026-07-15
 
 ### Added
@@ -273,7 +285,8 @@ Gem metadata only: corrected the gemspec description and README wording. No libr
 
 - ISIN numbers support: `SecID::ISIN`
 
-[Unreleased]: https://github.com/svyatov/sec_id/compare/v7.1.0...HEAD
+[Unreleased]: https://github.com/svyatov/sec_id/compare/v7.1.1...HEAD
+[7.1.1]: https://github.com/svyatov/sec_id/compare/v7.1.0...v7.1.1
 [7.1.0]: https://github.com/svyatov/sec_id/compare/v7.0.0...v7.1.0
 [7.0.0]: https://github.com/svyatov/sec_id/compare/v6.1.0...v7.0.0
 [6.1.0]: https://github.com/svyatov/sec_id/compare/v6.0.0...v6.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sec_id (7.1.0)
+    sec_id (7.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -286,7 +286,7 @@ CHECKSUMS
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
-  sec_id (7.1.0)
+  sec_id (7.1.1)
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simplecov (1.0.3) sha256=38ef0514f16ae7562f0d0f4df02610071115103d301b6de7dacbcc000082e39b
   simplecov-cobertura (4.0.0) sha256=e4fb3159b1ecea545b44f5452a8611305323e78ad23eae8aed35924d072e01ea

--- a/gemfiles/rails_7.2.gemfile.lock
+++ b/gemfiles/rails_7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    sec_id (7.1.0)
+    sec_id (7.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -328,7 +328,7 @@ CHECKSUMS
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
-  sec_id (7.1.0)
+  sec_id (7.1.1)
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simplecov (1.0.3) sha256=38ef0514f16ae7562f0d0f4df02610071115103d301b6de7dacbcc000082e39b
   simplecov-cobertura (4.0.0) sha256=e4fb3159b1ecea545b44f5452a8611305323e78ad23eae8aed35924d072e01ea

--- a/gemfiles/rails_8.0.gemfile.lock
+++ b/gemfiles/rails_8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    sec_id (7.1.0)
+    sec_id (7.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -325,7 +325,7 @@ CHECKSUMS
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
-  sec_id (7.1.0)
+  sec_id (7.1.1)
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simplecov (1.0.3) sha256=38ef0514f16ae7562f0d0f4df02610071115103d301b6de7dacbcc000082e39b
   simplecov-cobertura (4.0.0) sha256=e4fb3159b1ecea545b44f5452a8611305323e78ad23eae8aed35924d072e01ea

--- a/gemfiles/rails_8.1.gemfile.lock
+++ b/gemfiles/rails_8.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    sec_id (7.1.0)
+    sec_id (7.1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -323,7 +323,7 @@ CHECKSUMS
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
-  sec_id (7.1.0)
+  sec_id (7.1.1)
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   simplecov (1.0.3) sha256=38ef0514f16ae7562f0d0f4df02610071115103d301b6de7dacbcc000082e39b
   simplecov-cobertura (4.0.0) sha256=e4fb3159b1ecea545b44f5452a8611305323e78ad23eae8aed35924d072e01ea

--- a/lib/sec_id/version.rb
+++ b/lib/sec_id/version.rb
@@ -2,5 +2,5 @@
 
 module SecID
   # Current gem version.
-  VERSION = '7.1.0'
+  VERSION = '7.1.1'
 end


### PR DESCRIPTION
Patch release. Documentation and packaging only; nothing in `lib/` changed behaviour.

Everything since v7.1.0 is CI configuration, documentation, and RuboCop formatting. The `lib/` diff is comment and YARD additions plus a simplecov token migration, so no identifier, checksum, or public method moved. That makes this PATCH under SemVer.

What ships to users, since the gem packages `README.md`, `CHANGELOG.md`, and the gemspec:

- the README now declares the public API SemVer covers and names the `@api private` internals excluded from it
- the changelog version headings resolve, and 2.0.1 has the entry it never had
- the gem summary shown on RubyGems matches the README tagline

## This is also the first release through the new publish path

Pushing `v7.1.1` starts `.github/workflows/release.yml`, which tests the tagged commit, checks the tag against `SecID::VERSION`, and then stops at the `release` environment until a reviewer approves. Only after approval does it exchange an OIDC token, sign with sigstore, and push.

Two audit rules can only be verified by this actually running:

```bash
git tag -v v7.1.1                                                  # R-SEC-05
curl -s https://rubygems.org/api/v1/attestations/sec_id-7.1.1.json # R-PUB-03
```

## Note on the lockfiles

`rake lock:refresh` was required here and is not incidental. All four locks record `sec_id` as a path gem, so they carried `sec_id (7.1.0)` until refreshed, and every frozen CI job would have failed on the stale entry. This is the first release since the locks were committed, so it is also the first time that step has mattered.