### PR TITLE
docs: document the frozen-lockfile Ruby constraint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,10 @@ updates:
   #
   # Only a changed requirement needs that. The matrix gemfiles eval the root Gemfile, so
   # their locks record its requirement strings; a PR that edits one leaves them
-  # disagreeing, and the frozen install fails all four Rails jobs on the PR itself. A bump
-  # inside an unchanged requirement drifts silently and harmlessly. Red Rails jobs on an
-  # otherwise green Dependabot PR are the signal to relock.
+  # disagreeing, and the frozen install fails the three frozen Rails jobs (7.2, 8.0, 8.1)
+  # on the PR itself. The `head` job cannot catch it: it is unfrozen and continue-on-error.
+  # A bump inside an unchanged requirement drifts silently and harmlessly. Red Rails jobs
+  # on an otherwise green Dependabot PR are the signal to relock.
   - package-ecosystem: "bundler" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,28 @@ expected. The non-obvious ones:
 - **Regenerate CFI dynamic-method sigs**: `bundle exec rake sig:cfi`
 - **Documentation coverage gate**: `bundle exec rake yard:stats` (fails unless 100% of the public API is documented; a CI step)
 - **Run benchmarks**: `bundle exec rake bench` (machine-dependent, for catching regressions)
-- **Refresh lockfiles**: `bundle exec rake lock:refresh` (required after a version bump — see the release skill)
+- **Refresh lockfiles**: `bundle exec rake lock:refresh` (after a version bump or a dependency change — see below)
 
 The default `rake` task is `rubocop` + `rbs` + `spec`.
+
+### Dependencies and lockfiles
+
+Four lockfiles are committed (root plus `gemfiles/rails_{7.2,8.0,8.1}.gemfile.lock`) and CI installs
+them frozen, so the resolution is reviewable and GitHub's dependency graph sees transitive deps. Three
+consequences that are not visible from the files themselves:
+
+- **One lock must install on every Ruby in the matrix, down to 3.2.** Bundler resolves against the
+  *running* Ruby, so a lock written on 4.0 can pin a gem whose own `required_ruby_version` excludes
+  3.2, and the frozen install then fails only the oldest jobs. The gemspec's `required_ruby_version`
+  does not constrain this. `gem 'parallel', '< 2'` exists for exactly that reason.
+- **`RUBY_VERSION`-conditional Gemfile lines are impossible.** A frozen install compares the Gemfile's
+  evaluated dependency set against the lock's `DEPENDENCIES`, so a conditional line disagrees on every
+  Ruby but the one that wrote the lock.
+- **`rails_head.gemfile` ships no lock on purpose** (it tracks a git branch), so CI unfreezes that job
+  alone. It is also `continue-on-error`, so it can never be the job that catches lock drift.
+
+Run `bundle exec rake lock:refresh` after any dependency change, including merging a Dependabot PR
+that touches the root lock. Full write-up: `docs/solutions/build-errors/`.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,20 @@ bundle exec rubocop       # Run linter only
 bundle exec rubocop -a    # Auto-fix safe lint issues
 ```
 
+## Changing dependencies
+
+The lockfiles are committed and CI installs them frozen, so a dependency change is not complete until
+the lockfiles are regenerated:
+
+```bash
+bundle exec rake lock:refresh   # relocks the root Gemfile and the Rails matrix gemfiles
+```
+
+CI runs Ruby 3.2 through 4.0 against a single lockfile. Bundler resolves against whichever Ruby you
+run, so a lock written on a newer Ruby can pin a gem that will not install on 3.2, and only the oldest
+jobs fail. If that happens, pin the offending gem in the `Gemfile` with a comment saying when the pin
+can be lifted.
+
 ## Code style
 
 - **Ruby 3.2+** required


### PR DESCRIPTION
## What

Records the constraint that committed lockfiles plus frozen installs impose on this repo, and corrects one wrong comment.

CI installs four committed lockfiles frozen across a Ruby 3.2 to 4.0 matrix. The rule that follows was written down nowhere: Bundler resolves against the **running** Ruby, so one lock has to be installable on the oldest job in the matrix. That is the whole reason `gem 'parallel', '< 2'` exists, and until now it was reconstructable only from the pin's own comment.

## Changes

**`CLAUDE.md`** gains a `Dependencies and lockfiles` subsection with the three consequences that are not visible from the files:

- one lock must install down to Ruby 3.2, and the gemspec's `required_ruby_version` does not constrain this
- `RUBY_VERSION`-conditional Gemfile lines are impossible, because a frozen install compares the Gemfile's evaluated dependency set against the lock's `DEPENDENCIES`
- `rails_head.gemfile` ships no lock on purpose, and is also `continue-on-error`

Line 20 previously framed `rake lock:refresh` as a version-bump step only. It is also required after any dependency change, including merging a Dependabot PR.

**`CONTRIBUTING.md`** gains a `Changing dependencies` section. Without it, a contributor on a newer Ruby bumps a dev dependency, passes locally, and breaks every 3.2 job with no idea why.

**`.github/dependabot.yml`** had a factual error I introduced in #179: it claimed a changed requirement "fails all four Rails jobs on the PR itself". It fails three. The `head` job is unfrozen (`main.yml:108`) and `continue-on-error` (`main.yml:117`), so it re-resolves and can never reach a `DEPENDENCIES` mismatch. The narrowed rule still holds; only the count was wrong.

## Verification

Documentation only, no code or workflow behavior changes. `.github/dependabot.yml` still parses and both updater entries are intact.
