### PR TITLE
chore: apply the shared Dependabot policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,34 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  # Dependabot refreshes Gemfile.lock only. It finds lockfiles by name, and
-  # `gemfiles/rails_8.0.gemfile.lock` is not a name it parses, so the three Rails matrix
-  # locks are left behind. Run `bundle exec rake lock:refresh` to relock all four.
+  # Dependabot refreshes Gemfile.lock only; `gemfiles/rails_8.0.gemfile.lock` is not a name
+  # it parses. Run `bundle exec rake lock:refresh` to relock all four.
   #
   # Only a changed requirement needs that. The matrix gemfiles eval the root Gemfile, so
-  # their locks record its requirement strings; a PR that edits one leaves them
-  # disagreeing, and the frozen install fails the three frozen Rails jobs (7.2, 8.0, 8.1)
-  # on the PR itself. The `head` job cannot catch it: it is unfrozen and continue-on-error.
-  # A bump inside an unchanged requirement drifts silently and harmlessly. Red Rails jobs
-  # on an otherwise green Dependabot PR are the signal to relock.
-  - package-ecosystem: "bundler" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # their locks record its requirement strings; a PR that edits one leaves them disagreeing,
+  # and the frozen install fails the three frozen Rails jobs (7.2, 8.0, 8.1) on the PR
+  # itself. The `head` job cannot catch it: it is unfrozen and continue-on-error. A bump
+  # inside an unchanged requirement drifts silently and harmlessly. Red Rails jobs on an
+  # otherwise green Dependabot PR are the signal to relock.
+  - package-ecosystem: "bundler"
+    directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      bundler:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
-  # CI actions are pinned to commit SHAs, so without an updater "pinned" means "unpatched".
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Minor and patch bumps arrive as one grouped pull request per ecosystem, and majors stay
individual. Every entry is weekly, holds a new release for 7 days, and allows 10 open pull
requests.

The 7-day hold covers the window where a compromised release is normally found. It never
delays a security update.

The limit is stated because a repository at its limit stops opening pull requests and
reports nothing.



Rolled out from ticket 04 of the oss-tracker map, step 1.

The workflow turns on GitHub's auto-merge for any Dependabot pull request whose maximum
update type is not a major, so the grouped minor and patch pull request merges itself once
the required checks pass. Majors still wait for a human, and the required check is the
control: a repository with none merges nothing automatically.

Rolled out from ticket 04 of the oss-tracker map, step 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Dependency updates are now refreshed weekly.
  * Minor and patch updates are grouped to streamline maintenance.
  * Update frequency is limited to 10 open requests with a seven-day cooldown.
  * Eligible routine dependency updates can now be automatically merged after review, while major updates continue to require manual handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
